### PR TITLE
[Feat] : 재료 상태 FSM 및 스프라이트 처리 완료 (고기, 버섯 제외)

### DIFF
--- a/Client/Code/CCucumber.cpp
+++ b/Client/Code/CCucumber.cpp
@@ -1,5 +1,9 @@
 #include "pch.h"
 #include "CCucumber.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "IState.h"
+#include "CFontMgr.h"
 
 CCucumber::CCucumber(LPDIRECT3DDEVICE9 pGraphicDev)
 	: CIngredient(pGraphicDev)
@@ -17,32 +21,98 @@ CCucumber::~CCucumber()
 
 HRESULT CCucumber::Ready_GameObject()
 {
+	if (FAILED(Add_Component()))
+		return E_FAIL;
+
+	m_eType = CUCUMBER;
+	m_eCookState = RAW;
+	m_pCurrentState = new IRawState();
+	m_pTransformCom->Set_Pos(2.f, m_pTransformCom->Get_Scale().y, 2.f);
+
 	return S_OK;
 }
 
 _int CCucumber::Update_GameObject(const _float& fTimeDelta)
 {
-	return 0;
+	int iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+	CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+	if (m_pCurrentState)
+		m_pCurrentState->Update_State(this, fTimeDelta);
+
+	//// FMS 디버깅 임시
+	//if (GetAsyncKeyState('N'))
+	//	Add_Progress(fTimeDelta, 0.5f);
+	//swprintf_s(m_szProgress, L"오이 : %d, %f", m_eCookState, m_fProgress);
+	////
+
+	return iExit;
 }
 
 void CCucumber::LateUpdate_GameObject(const _float& fTimeDelta)
 {
+	Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
 }
 
 void CCucumber::Render_GameObject()
 {
+	m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+	int iIndex = 0;
+	if (DONE == m_eCookState || CHOPPED == m_eCookState)
+		iIndex = 1;
+	m_pTextureCom->Set_Texture(iIndex);
+
+	m_pBufferCom->Render_Buffer();
+
+	//// FMS 디버깅 임시
+	//_vec2   vPos{ 100.f, 100.f };
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	////
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
 }
 
 HRESULT CCucumber::Add_Component()
 {
+	CComponent* pComponent = nullptr;
+
+	pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+	pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+	pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_IngredientTexture_Cucumber"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Texture", pComponent });
+
 	return S_OK;
 }
 
 CCucumber* CCucumber::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 {
-	return nullptr;
+	CCucumber* pCucumber = new CCucumber(pGraphicDev);
+
+	if (FAILED(pCucumber->Ready_GameObject()))
+	{
+		Safe_Release(pCucumber);
+		MSG_BOX("Cucumber Create Failed");
+		return nullptr;
+	}
+
+	return pCucumber;
 }
 
 void CCucumber::Free()
 {
+	CIngredient::Free();
 }

--- a/Client/Code/CFish.cpp
+++ b/Client/Code/CFish.cpp
@@ -1,5 +1,9 @@
 #include "pch.h"
 #include "CFish.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "IState.h"
+#include "CFontMgr.h"
 
 CFish::CFish(LPDIRECT3DDEVICE9 pGraphicDev)
 	: CIngredient(pGraphicDev)
@@ -17,32 +21,98 @@ CFish::~CFish()
 
 HRESULT CFish::Ready_GameObject()
 {
+	if (FAILED(Add_Component()))
+		return E_FAIL;
+
+	m_eType = FISH;
+	m_eCookState = RAW;
+	m_pCurrentState = new IRawState();
+	m_pTransformCom->Set_Pos(2.f, m_pTransformCom->Get_Scale().y, 2.f);
+
 	return S_OK;
 }
 
 _int CFish::Update_GameObject(const _float& fTimeDelta)
 {
-	return 0;
+	int iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+	CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+	if (m_pCurrentState)
+		m_pCurrentState->Update_State(this, fTimeDelta);
+
+	//// FMS 디버깅 임시
+	//if (GetAsyncKeyState('N'))
+	//	Add_Progress(fTimeDelta, 0.5f);
+	//swprintf_s(m_szProgress, L"생선 : %d, %f", m_eCookState, m_fProgress);
+	////
+
+	return iExit;
 }
 
 void CFish::LateUpdate_GameObject(const _float& fTimeDelta)
 {
+	Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
 }
 
 void CFish::Render_GameObject()
 {
+	m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+	int iIndex = 0;
+	if (DONE == m_eCookState || CHOPPED == m_eCookState)
+		iIndex = 1;
+	m_pTextureCom->Set_Texture(iIndex);
+
+	m_pBufferCom->Render_Buffer();
+
+	//// FMS 디버깅 임시
+	//_vec2   vPos{ 100.f, 100.f };
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	////
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
 }
 
 HRESULT CFish::Add_Component()
 {
+	CComponent* pComponent = nullptr;
+
+	pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+	pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+	pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_IngredientTexture_Fish"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Texture", pComponent });
+
 	return S_OK;
 }
 
 CFish* CFish::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 {
-	return nullptr;
+	CFish* pFish = new CFish(pGraphicDev);
+
+	if (FAILED(pFish->Ready_GameObject()))
+	{
+		Safe_Release(pFish);
+		MSG_BOX("Lettuce Create Failed");
+		return nullptr;
+	}
+
+	return pFish;
 }
 
 void CFish::Free()
 {
+	CIngredient::Free();
 }

--- a/Client/Code/CIngredient.cpp
+++ b/Client/Code/CIngredient.cpp
@@ -3,43 +3,31 @@
 #include "IState.h"
 
 CIngredient::CIngredient(LPDIRECT3DDEVICE9 pGraphicDev)
-	: CInteract(pGraphicDev), m_eType(ING_END), m_eCookState(CS_END), m_pCurrentState(nullptr), m_fProgress(0.f)
+	: CInteract(pGraphicDev), m_eType(ING_END), m_eCookState(RAW), m_pCurrentState(nullptr), m_fProgress(0.f)
 {
+	ZeroMemory(m_szProgress, sizeof(m_szProgress));
 }
 
 CIngredient::CIngredient(const CGameObject& rhs)
-	: CInteract(rhs)
+	: CInteract(rhs), m_eType(ING_END), m_eCookState(CS_END), m_pCurrentState(nullptr), m_fProgress(0.f)
 {
+	ZeroMemory(m_szProgress, sizeof(m_szProgress));
 }
 
 CIngredient::~CIngredient()
 {
 }
 
-_bool CIngredient::Is_FinalStep() const
-{
-	return false;
-}
-
-void CIngredient::Set_Done()
-{
-	m_eCookState = DONE;
-}
-
 void CIngredient::Set_Progress(const _float& fProgress)
-{	
-	m_fProgress = fProgress;
-
-	if (1.f <= fProgress)
-		m_fProgress = 1.f;
+{
+	if (Check_Progress())
+		m_fProgress = fProgress;
 }
 
 void CIngredient::Add_Progress(const _float& fTimeDelta, const _float& fAdd)
 {
-	m_fProgress += fAdd * fTimeDelta;
-
-	if (1.f <=m_fProgress)
-		m_fProgress = 1.f;
+	if (Check_Progress())
+		m_fProgress += fAdd * fTimeDelta;
 }
 
 void CIngredient::ChangeState(IState* pNextState)
@@ -53,6 +41,25 @@ void CIngredient::ChangeState(IState* pNextState)
 	m_pCurrentState = pNextState;
 	if (m_pCurrentState)
 		m_pCurrentState->Enter_State(this);
+}
+
+bool CIngredient::Check_Progress()
+{
+	if (Get_Type() == SEAWEED)
+		return false;
+	else if (Get_Type() == LETTUCE || Get_Type() == TOMATO || Get_Type() == CUCUMBER || Get_Type() == FISH || Get_Type() == SHRIMP)
+	{
+		if (Get_State() != RAW)
+			return false;
+	}
+	else if (Get_Type() == RICE || Get_Type() == PASTA)
+	{
+		//if (Get_State() == DONE)
+		//	return false;
+	}
+	// else if (토마토 소스) RAW, CHOP에서만 Progress 진행
+
+	return true;
 }
 
 void CIngredient::Free()

--- a/Client/Code/CLettuce.cpp
+++ b/Client/Code/CLettuce.cpp
@@ -8,13 +8,11 @@
 CLettuce::CLettuce(LPDIRECT3DDEVICE9 pGraphicDev)
 	: CIngredient(pGraphicDev)
 {
-	ZeroMemory(m_szProgress, sizeof(m_szProgress));
 }
 
 CLettuce::CLettuce(const CGameObject& rhs)
 	: CIngredient(rhs)
 {
-	ZeroMemory(m_szProgress, sizeof(m_szProgress));
 }
 
 CLettuce::~CLettuce()
@@ -27,6 +25,7 @@ HRESULT CLettuce::Ready_GameObject()
 		return E_FAIL;
 
 	m_eType = LETTUCE;
+	m_eCookState = RAW;
 	m_pCurrentState = new IRawState();
 	m_pTransformCom->Set_Pos(2.f, m_pTransformCom->Get_Scale().y, 2.f);
 
@@ -38,16 +37,15 @@ _int CLettuce::Update_GameObject(const _float& fTimeDelta)
 	int iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
 
 	CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+	
+	if (m_pCurrentState)
+		m_pCurrentState->Update_State(this, fTimeDelta);
 
-	// 테스트 코드
-	// if (GetAsyncKeyState(VK_SPACE))
-	// 	Add_Progress(fTimeDelta, 0.1f);
-	// 
-	// if (m_pCurrentState)
-	// 	m_pCurrentState->Update_State(this, fTimeDelta);
-
-	swprintf_s(m_szProgress, L"%f", m_fProgress);
-	//
+	//// FMS 디버깅 임시
+	//if (GetAsyncKeyState('N'))
+	//	Add_Progress(fTimeDelta, 0.5f);
+	//swprintf_s(m_szProgress, L"양배추 : %d, %f", m_eCookState, m_fProgress);
+	////
 
 	return iExit;
 }
@@ -64,27 +62,17 @@ void CLettuce::Render_GameObject()
 	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
 	
 	int iIndex = 0;
-
-	switch (m_eCookState)
-	{
-	case RAW : 
-		iIndex = 0;
-		break;
-	case CHOPPED:
-	case DONE:
+	if (DONE == m_eCookState || CHOPPED == m_eCookState)
 		iIndex = 1;
-		break;
-	}
-
 	m_pTextureCom->Set_Texture(iIndex);
-
-	// 디버깅 임시
-	_vec2   vPos{ 100.f, 100.f };
-	CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
-	//
 
 	m_pBufferCom->Render_Buffer();
 	
+	//// FMS 디버깅 임시
+	//_vec2   vPos{ 100.f, 100.f };
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	////
+
 	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
 }
 

--- a/Client/Code/CLoading.cpp
+++ b/Client/Code/CLoading.cpp
@@ -91,6 +91,10 @@ _uint CLoading::Loaing_ForStage()
 		return E_FAIL;
 
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_IngredientTexture_Seaweed", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/ingredient/ingredient_seaweed%d.png", TEX_NORMAL))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
 	(L"Proto_IngredientTexture_Lettuce", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/ingredient/ingredient_lettuce%d.png", TEX_NORMAL, 2))))
 		return E_FAIL;
 
@@ -100,6 +104,22 @@ _uint CLoading::Loaing_ForStage()
 
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
 	(L"Proto_IngredientTexture_Cucumber", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/ingredient/ingredient_cucumber%d.png", TEX_NORMAL, 2))))
+		return E_FAIL;
+	
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_IngredientTexture_Fish", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/ingredient/ingredient_fish%d.png", TEX_NORMAL, 2))))
+		return E_FAIL;
+	
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_IngredientTexture_Shrimp", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/ingredient/ingredient_shrimp%d.png", TEX_NORMAL, 2))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_IngredientTexture_Rice", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/ingredient/ingredient_rice%d.png", TEX_NORMAL, 4))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_IngredientTexture_Pasta", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/ingredient/ingredient_pasta%d.png", TEX_NORMAL, 4))))
 		return E_FAIL;
 
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype

--- a/Client/Code/CPasta.cpp
+++ b/Client/Code/CPasta.cpp
@@ -1,5 +1,9 @@
 #include "pch.h"
 #include "CPasta.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "IState.h"
+#include "CFontMgr.h"
 
 CPasta::CPasta(LPDIRECT3DDEVICE9 pGraphicDev)
 	: CIngredient(pGraphicDev)
@@ -17,32 +21,105 @@ CPasta::~CPasta()
 
 HRESULT CPasta::Ready_GameObject()
 {
+	if (FAILED(Add_Component()))
+		return E_FAIL;
+
+	m_eType = RICE;
+	m_eCookState = RAW;
+	m_pCurrentState = new IRawState();
+	m_pTransformCom->Set_Pos(5.f, m_pTransformCom->Get_Scale().y, 2.f);
+
 	return S_OK;
 }
 
 _int CPasta::Update_GameObject(const _float& fTimeDelta)
 {
-	return 0;
+	int iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+	CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+	if (m_pCurrentState)
+		m_pCurrentState->Update_State(this, fTimeDelta);
+
+	if (COOKED == m_eCookState || DONE == m_eCookState)
+		Add_Progress(fTimeDelta);
+
+	//// FMS µð¹ö±ë ÀÓ½Ã
+	//if (RAW == m_eCookState && GetAsyncKeyState('B'))
+	//	Set_Progress(1.f);	// Add_Progress(fTimeDelta, 0.5f);
+	//swprintf_s(m_szProgress, L"½Ò : %d, %f", m_eCookState, m_fProgress);
+	////
+
+	return iExit;
 }
 
 void CPasta::LateUpdate_GameObject(const _float& fTimeDelta)
 {
+	Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
 }
 
 void CPasta::Render_GameObject()
 {
+	m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+	int iIndex = 0;
+	if (COOKED == m_eCookState)
+		iIndex = 1;
+	else if (DONE == m_eCookState)
+		iIndex = 2;
+	if (BURNT == m_eCookState)
+		iIndex = 3;
+	m_pTextureCom->Set_Texture(iIndex);
+
+	m_pBufferCom->Render_Buffer();
+
+	//// FMS µð¹ö±ë ÀÓ½Ã
+	//_vec2   vPos{ 100.f, 150.f };
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	////
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
 }
 
 HRESULT CPasta::Add_Component()
 {
+	CComponent* pComponent = nullptr;
+
+	pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+	pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+	pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_IngredientTexture_Pasta"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Texture", pComponent });
+
 	return S_OK;
 }
 
 CPasta* CPasta::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 {
-	return nullptr;
+	CPasta* pPasta = new CPasta(pGraphicDev);
+
+	if (FAILED(pPasta->Ready_GameObject()))
+	{
+		Safe_Release(pPasta);
+		MSG_BOX("Pasta Create Failed");
+		return nullptr;
+	}
+
+	return pPasta;
 }
 
 void CPasta::Free()
 {
+	CIngredient::Free();
 }

--- a/Client/Code/CRice.cpp
+++ b/Client/Code/CRice.cpp
@@ -1,5 +1,9 @@
 #include "pch.h"
 #include "CRice.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "IState.h"
+#include "CFontMgr.h"
 
 CRice::CRice(LPDIRECT3DDEVICE9 pGraphicDev)
 	: CIngredient(pGraphicDev)
@@ -17,32 +21,105 @@ CRice::~CRice()
 
 HRESULT CRice::Ready_GameObject()
 {
+	if (FAILED(Add_Component()))
+		return E_FAIL;
+
+	m_eType = RICE;
+	m_eCookState = RAW;
+	m_pCurrentState = new IRawState();
+	m_pTransformCom->Set_Pos(5.f, m_pTransformCom->Get_Scale().y, 2.f);
+
 	return S_OK;
 }
 
 _int CRice::Update_GameObject(const _float& fTimeDelta)
 {
-	return 0;
+	int iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+	CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+	if (m_pCurrentState)
+		m_pCurrentState->Update_State(this, fTimeDelta);
+
+	if (COOKED == m_eCookState || DONE == m_eCookState)
+		Add_Progress(fTimeDelta);
+
+	//// FMS µð¹ö±ë ÀÓ½Ã
+	//if (RAW == m_eCookState && GetAsyncKeyState('B'))
+	//	Set_Progress(1.f);//` Add_Progress(fTimeDelta, 0.5f);
+	//swprintf_s(m_szProgress, L"½Ò : %d, %f", m_eCookState, m_fProgress);
+	////
+
+	return iExit;
 }
 
 void CRice::LateUpdate_GameObject(const _float& fTimeDelta)
 {
+	Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
 }
 
 void CRice::Render_GameObject()
 {
+	m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+	int iIndex = 0;
+	if (COOKED == m_eCookState)
+		iIndex = 1;
+	else if (DONE == m_eCookState)
+		iIndex = 2;
+	if (BURNT == m_eCookState)
+		iIndex = 3;
+	m_pTextureCom->Set_Texture(iIndex);
+
+	m_pBufferCom->Render_Buffer();
+
+	//// FMS µð¹ö±ë ÀÓ½Ã
+	//_vec2   vPos{ 100.f, 150.f };
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	////
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
 }
 
 HRESULT CRice::Add_Component()
 {
+	CComponent* pComponent = nullptr;
+
+	pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+	pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+	pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_IngredientTexture_Rice"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Texture", pComponent });
+
 	return S_OK;
 }
 
 CRice* CRice::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 {
-	return nullptr;
+	CRice* pRice = new CRice(pGraphicDev);
+
+	if (FAILED(pRice->Ready_GameObject()))
+	{
+		Safe_Release(pRice);
+		MSG_BOX("Rice Create Failed");
+		return nullptr;
+	}
+
+	return pRice;
 }
 
 void CRice::Free()
 {
+	CIngredient::Free();
 }

--- a/Client/Code/CSeaweed.cpp
+++ b/Client/Code/CSeaweed.cpp
@@ -1,5 +1,9 @@
 #include "pch.h"
 #include "CSeaweed.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "IState.h"
+#include "CFontMgr.h"
 
 CSeaweed::CSeaweed(LPDIRECT3DDEVICE9 pGraphicDev)
 	: CIngredient(pGraphicDev)
@@ -17,32 +21,96 @@ CSeaweed::~CSeaweed()
 
 HRESULT CSeaweed::Ready_GameObject()
 {
+	if (FAILED(Add_Component()))
+		return E_FAIL;
+
+	m_eType = SEAWEED;
+	m_eCookState = RAW;
+	m_pCurrentState = new IRawState();
+	m_pTransformCom->Set_Pos(0.f, m_pTransformCom->Get_Scale().y, 2.f);
+
 	return S_OK;
 }
 
 _int CSeaweed::Update_GameObject(const _float& fTimeDelta)
 {
-	return 0;
+	int iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+	CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+	if (m_pCurrentState)
+		m_pCurrentState->Update_State(this, fTimeDelta);
+
+	//// FMS 디버깅 임시
+	//if (GetAsyncKeyState('M'))
+	//	Add_Progress(fTimeDelta, 0.5f);
+	//swprintf_s(m_szProgress, L"다시마 : %d, %f", m_eCookState, m_fProgress);
+	////
+
+	return iExit;
 }
 
 void CSeaweed::LateUpdate_GameObject(const _float& fTimeDelta)
 {
+	Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
 }
 
 void CSeaweed::Render_GameObject()
 {
+	m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+	int iIndex = 0;
+	m_pTextureCom->Set_Texture(iIndex);
+	
+	m_pBufferCom->Render_Buffer();
+
+	//// FMS 디버깅 임시
+	//_vec2   vPos{ 100.f, 50.f };
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	////
+	
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
 }
 
 HRESULT CSeaweed::Add_Component()
 {
+	CComponent* pComponent = nullptr;
+
+	pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+	pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+	pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_IngredientTexture_Seaweed"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Texture", pComponent });
+
 	return S_OK;
 }
 
 CSeaweed* CSeaweed::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 {
-	return nullptr;
+	CSeaweed* pSeaweed = new CSeaweed(pGraphicDev);
+
+	if (FAILED(pSeaweed->Ready_GameObject()))
+	{
+		Safe_Release(pSeaweed);
+		MSG_BOX("Seaweed Create Failed");
+		return nullptr;
+	}
+
+	return pSeaweed;
 }
 
 void CSeaweed::Free()
 {
+	CIngredient::Free();
 }

--- a/Client/Code/CShrimp.cpp
+++ b/Client/Code/CShrimp.cpp
@@ -1,5 +1,9 @@
 #include "pch.h"
 #include "CShrimp.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "IState.h"
+#include "CFontMgr.h"
 
 CShrimp::CShrimp(LPDIRECT3DDEVICE9 pGraphicDev)
 	: CIngredient(pGraphicDev)
@@ -17,32 +21,98 @@ CShrimp::~CShrimp()
 
 HRESULT CShrimp::Ready_GameObject()
 {
+	if (FAILED(Add_Component()))
+		return E_FAIL;
+
+	m_eType = FISH;
+	m_eCookState = RAW;
+	m_pCurrentState = new IRawState();
+	m_pTransformCom->Set_Pos(2.f, m_pTransformCom->Get_Scale().y, 2.f);
+
 	return S_OK;
 }
 
 _int CShrimp::Update_GameObject(const _float& fTimeDelta)
 {
-	return 0;
+	int iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+	CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+	if (m_pCurrentState)
+		m_pCurrentState->Update_State(this, fTimeDelta);
+
+	//// FMS 디버깅 임시
+	//if (GetAsyncKeyState('N'))
+	//	Add_Progress(fTimeDelta, 0.5f);
+	//swprintf_s(m_szProgress, L"새우 : %d, %f", m_eCookState, m_fProgress);
+	////
+
+	return iExit;
 }
 
 void CShrimp::LateUpdate_GameObject(const _float& fTimeDelta)
 {
+	Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
 }
 
 void CShrimp::Render_GameObject()
 {
+	m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+	int iIndex = 0;
+	if (DONE == m_eCookState || CHOPPED == m_eCookState)
+		iIndex = 1;
+	m_pTextureCom->Set_Texture(iIndex);
+
+	m_pBufferCom->Render_Buffer();
+
+	//// FMS 디버깅 임시
+	//_vec2   vPos{ 100.f, 100.f };
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	////
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
 }
 
 HRESULT CShrimp::Add_Component()
 {
+	CComponent* pComponent = nullptr;
+
+	pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+	pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+	pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_IngredientTexture_Shrimp"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Texture", pComponent });
+
 	return S_OK;
 }
 
 CShrimp* CShrimp::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 {
-	return nullptr;
+	CShrimp* pShrimp = new CShrimp(pGraphicDev);
+
+	if (FAILED(pShrimp->Ready_GameObject()))
+	{
+		Safe_Release(pShrimp);
+		MSG_BOX("Shrimp Create Failed");
+		return nullptr;
+	}
+
+	return pShrimp;
 }
 
 void CShrimp::Free()
 {
+	CIngredient::Free();
 }

--- a/Client/Code/CStage.cpp
+++ b/Client/Code/CStage.cpp
@@ -9,7 +9,14 @@
 #include "CSkyBox.h"
 #include "CLightMgr.h"
 #include "CEffect.h"
+#include "CSeaweed.h"
 #include "CLettuce.h"
+#include "CTomato.h"
+#include "CCucumber.h"
+#include "CFish.h"
+#include "CShrimp.h"
+#include "CRice.h"
+#include "CPasta.h"
 #include "CEmptyStation.h"
 #include "CFloor.h"
 
@@ -117,10 +124,22 @@ HRESULT CStage::Ready_GameObject_Layer(const _tchar* pLayerTag)
     if (FAILED(pLayer->Add_GameObject(L"Monster", pGameObject)))
         return E_FAIL;
 
-    pGameObject = CLettuce::Create(m_pGraphicDev);
+    pGameObject = CSeaweed::Create(m_pGraphicDev);
     if (nullptr == pGameObject)
         return E_FAIL;
-    if (FAILED(pLayer->Add_GameObject(L"Ingredient_Lettuce", pGameObject)))
+    if (FAILED(pLayer->Add_GameObject(L"Ingredient_Seaweed", pGameObject)))
+        return E_FAIL;
+
+    pGameObject = CShrimp::Create(m_pGraphicDev);
+    if (nullptr == pGameObject)
+        return E_FAIL;
+    if (FAILED(pLayer->Add_GameObject(L"Ingredient_Shrimp", pGameObject)))
+        return E_FAIL;
+
+    pGameObject = CPasta::Create(m_pGraphicDev);
+    if (nullptr == pGameObject)
+        return E_FAIL;
+    if (FAILED(pLayer->Add_GameObject(L"Ingredient_Pasta", pGameObject)))
         return E_FAIL;
 
     pGameObject = CEmptyStation::Create(m_pGraphicDev);

--- a/Client/Code/CTomato.cpp
+++ b/Client/Code/CTomato.cpp
@@ -1,5 +1,9 @@
 #include "pch.h"
 #include "CTomato.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "IState.h"
+#include "CFontMgr.h"
 
 CTomato::CTomato(LPDIRECT3DDEVICE9 pGraphicDev)
 	: CIngredient(pGraphicDev)
@@ -17,32 +21,98 @@ CTomato::~CTomato()
 
 HRESULT CTomato::Ready_GameObject()
 {
+	if (FAILED(Add_Component()))
+		return E_FAIL;
+
+	m_eType = TOMATO;
+	m_eCookState = RAW;
+	m_pCurrentState = new IRawState();
+	m_pTransformCom->Set_Pos(2.f, m_pTransformCom->Get_Scale().y, 2.f);
+
 	return S_OK;
 }
 
 _int CTomato::Update_GameObject(const _float& fTimeDelta)
 {
-	return 0;
+	int iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+	CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+	if (m_pCurrentState)
+		m_pCurrentState->Update_State(this, fTimeDelta);
+
+	//// FMS 디버깅 임시
+	//if (GetAsyncKeyState('N'))
+	//	Add_Progress(fTimeDelta, 0.5f);
+	//swprintf_s(m_szProgress, L"토마토 : %d, %f", m_eCookState, m_fProgress);
+	////
+
+	return iExit;
 }
 
 void CTomato::LateUpdate_GameObject(const _float& fTimeDelta)
 {
+	Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
 }
 
 void CTomato::Render_GameObject()
 {
+	m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+	int iIndex = 0;
+	if (DONE == m_eCookState || CHOPPED == m_eCookState)
+		iIndex = 1;
+	m_pTextureCom->Set_Texture(iIndex);
+
+	m_pBufferCom->Render_Buffer();
+
+	//// FMS 디버깅 임시
+	//_vec2   vPos{ 100.f, 100.f };
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	////
+
+	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
 }
 
 HRESULT CTomato::Add_Component()
 {
+	CComponent* pComponent = nullptr;
+
+	pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+	pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+	pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_IngredientTexture_Tomato"));
+	if (nullptr == pComponent)
+		return E_FAIL;
+	m_mapComponent[ID_DYNAMIC].insert({ L"Com_Texture", pComponent });
+
 	return S_OK;
 }
 
 CTomato* CTomato::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 {
-	return nullptr;
+	CTomato* pTomato = new CTomato(pGraphicDev);
+
+	if (FAILED(pTomato->Ready_GameObject()))
+	{
+		Safe_Release(pTomato);
+		MSG_BOX("Tomato Create Failed");
+		return nullptr;
+	}
+
+	return pTomato;
 }
 
 void CTomato::Free()
 {
+	CIngredient::Free();
 }

--- a/Client/Header/CIngredient.h
+++ b/Client/Header/CIngredient.h
@@ -4,7 +4,7 @@
 * @author	권예지
 * @brief	재료 클래스 (조리 상태 및 진행도 관련)
 * @details	플레이어가 조작 가능한 재료 오브젝트.
-*			ICarry를 통해 들고 이동 가능하며, IState를 통해 조리 상태 변화가 가능하고, 함수를 호출해서 진행도를 관리.
+*			ICarry를 통해 들고 이동 가능하며, IState를 통해 조리 상태 변화가 가능하고, 진행도를 관리.
 */
 #pragma once
 #include "CInteract.h"
@@ -21,9 +21,9 @@ public:
 	enum COOKSTATE { 
 		RAW,///< 가공되지 않은 상태 (생 재료)
 		CHOPPED,///< 썬 상태
-		COOKED,///< 익힌 상태
-		BURNT,///< 탄 상태
+		COOKED,///< 익힌 상태 
 		DONE,///< 최종 조리 완료 상태 (접시에 올릴 수 있음)
+		BURNT,///< 탄 상태
 		CS_END///< 조리상태 끝
 	};
 
@@ -76,17 +76,6 @@ public:
 	virtual		void		Set_State(COOKSTATE eState) { m_eCookState = eState; }
 
 	/**
-	* @brief 재료의 조리 상태가 DONE 인지 확인하는 함수.
-	* @return 완료 상태일 경우 true, 그렇지 않으면 false.
-	*/
-	virtual		_bool		Is_FinalStep() const;
-
-	/**
-	* @brief 재료의 상태를 DONE으로 설정하는 함수.
-	*/
-	virtual		void		Set_Done();
-
-	/**
 	* @brief 현재 조리 진행도를 반환하는 함수.
 	* @return 진행도 (0.0f ~ 1.0f 범위의 값) 리턴.
 	*/
@@ -100,9 +89,9 @@ public:
 
 	/**
 	* @brief 조리 진행도를 증가시키는 함수.
-	* @param fAdd : 더할 진행도 값. (0.f ~ 1.f)
+	* @param fAdd : 더할 진행도 값. (디폴트 : 0.005f, 범위 : 0.f ~ 1.f)
 	*/
-	virtual		void		Add_Progress(const _float& fTimeDelta, const _float& fAdd = 0.005f);
+	virtual		void		Add_Progress(const _float& fTimeDelta, const _float& fAdd = 0.1f);
 	 
 	/**
 	* @brief IState*를  변경하는 함수.
@@ -110,11 +99,16 @@ public:
 	*/
 	virtual		void		ChangeState(IState* pNextState);
 
+private:
+	virtual		bool		Check_Progress();
+
 protected:
 	INGREDIENT_TYPE			m_eType;	///< 열거형 INGREDIENT_TYPE 변수 (재료의 종류)
 	COOKSTATE				m_eCookState;	///< 열거형 COOKSTATE 변수 (재료의 조리 상태)
 	IState*					m_pCurrentState;	///< IState* 재료 FMS
 	_float					m_fProgress;	///< 실수형 변수 (재료의 조리 진행도) (0.0f ~ 1.0f 범위) 
+
+	_tchar					m_szProgress[128];	// 디버깅 위해 임시로 사용
 
 protected:
 	virtual		void		Free();

--- a/Client/Header/CLettuce.h
+++ b/Client/Header/CLettuce.h
@@ -29,13 +29,12 @@ public:
 	virtual		void		Render_GameObject();
 
 private:
-	HRESULT		Add_Component();
+	HRESULT					Add_Component();
 
 private:
 	Engine::CRcTex* m_pBufferCom;
 	Engine::CTransform* m_pTransformCom;
 	Engine::CTexture* m_pTextureCom;
-	_tchar						m_szProgress[128];	// 디버깅 위해 임시로 사용
 
 public:
 	static		CLettuce*	Create(LPDIRECT3DDEVICE9 pGraphicDev);

--- a/Client/Header/CSeaweed.h
+++ b/Client/Header/CSeaweed.h
@@ -29,7 +29,7 @@ public:
 	virtual		void		Render_GameObject();
 
 private:
-	HRESULT		Add_Component();
+	HRESULT					Add_Component();
 
 private:
 	Engine::CRcTex* m_pBufferCom;

--- a/Client/Header/CTomato.h
+++ b/Client/Header/CTomato.h
@@ -29,7 +29,7 @@ public:
 	virtual		void		Render_GameObject();
 
 private:
-	HRESULT		Add_Component();
+	HRESULT					Add_Component();
 
 private:
 	Engine::CRcTex* m_pBufferCom;

--- a/Client/Include/IState.cpp
+++ b/Client/Include/IState.cpp
@@ -9,12 +9,20 @@ void IRawState::Enter_State(CIngredient* pIngredient)
 
 void IRawState::Update_State(CIngredient* pIngredient, const _float& fTiemDelta)
 {
-	if (1.f > pIngredient->Get_Progress())
-		return;
-
 	CIngredient::INGREDIENT_TYPE eType = pIngredient->Get_Type();
-	if (eType == CIngredient::LETTUCE || eType == CIngredient::TOMATO || eType == CIngredient::CUCUMBER || eType == CIngredient::FISH || eType == CIngredient::SHRIMP)
-		pIngredient->ChangeState(new IChopState());
+
+	if (1.f > pIngredient->Get_Progress())
+	{
+		if (eType == CIngredient::SEAWEED)
+			pIngredient->Set_State(CIngredient::DONE);
+	}
+	else
+	{
+		if (eType == CIngredient::LETTUCE || eType == CIngredient::TOMATO || eType == CIngredient::CUCUMBER || eType == CIngredient::FISH || eType == CIngredient::SHRIMP)
+			pIngredient->ChangeState(new IChopState());
+		else if (eType == CIngredient::RICE || eType == CIngredient::PASTA)
+			pIngredient->ChangeState(new ICookState());
+	} 
 }
 
 void IRawState::Exit_State(CIngredient* pIngredient)
@@ -29,12 +37,17 @@ void IChopState::Enter_State(CIngredient* pIngredient)
 
 void IChopState::Update_State(CIngredient* pIngredient, const _float& fTiemDelta)
 {
-	if (1.f > pIngredient->Get_Progress())
-		return;
-
 	CIngredient::INGREDIENT_TYPE eType = pIngredient->Get_Type();
-	if (eType == CIngredient::LETTUCE)
-		pIngredient->Set_Done();
+
+	if (1.f > pIngredient->Get_Progress())
+	{
+	if (eType == CIngredient::LETTUCE || eType == CIngredient::TOMATO || eType == CIngredient::CUCUMBER || eType == CIngredient::FISH || eType == CIngredient::SHRIMP)
+		pIngredient->Set_State(CIngredient::DONE);
+	}
+	else
+	{
+		// 토마토스프는 프로그레스 1 되면 ChangeState(new ICook());
+	}
 }
 
 void IChopState::Exit_State(CIngredient* pIngredient)
@@ -49,8 +62,26 @@ void ICookState::Enter_State(CIngredient* pIngredient)
 
 void ICookState::Update_State(CIngredient* pIngredient, const _float& fTiemDelta)
 {
+	if (1.f <= pIngredient->Get_Progress())
+		pIngredient->ChangeState(new IDoneState());
 }
 
 void ICookState::Exit_State(CIngredient* pIngredient)
+{
+}
+
+void IDoneState::Enter_State(CIngredient* pIngredient)
+{
+	pIngredient->Set_Progress(0.f);
+	pIngredient->Set_State(CIngredient::DONE);
+}
+
+void IDoneState::Update_State(CIngredient* pIngredient, const _float& fTiemDelta)
+{
+	if (1.f <= pIngredient->Get_Progress())
+		pIngredient->Set_State(CIngredient::BURNT);
+}
+
+void IDoneState::Exit_State(CIngredient* pIngredient)
 {
 }

--- a/Client/Include/IState.h
+++ b/Client/Include/IState.h
@@ -41,3 +41,11 @@ class ICookState : public IState {
 	void Exit_State(CIngredient* pIngredient) override;
 	virtual ~ICookState() = default;
 };
+
+class IDoneState : public IState {
+	// IState을(를) 통해 상속됨
+	void Enter_State(CIngredient* pIngredient) override;
+	void Update_State(CIngredient* pIngredient, const _float& fTiemDelta) override;
+	void Exit_State(CIngredient* pIngredient) override;
+	virtual ~IDoneState() = default;
+};


### PR DESCRIPTION
- IState 인터페이스를 활용한 재료 상태 전환 로직 구현
- 각 상태별 스프라이트 출력 적용
- 고기, 버섯은 해당 스테이지 미사용으로 구현 제외