### PR TITLE
[Feat] : IChop 도마에서 재료 썰기 구현

### DIFF
--- a/Client/Code/CCucumber.cpp
+++ b/Client/Code/CCucumber.cpp
@@ -47,7 +47,7 @@ _int CCucumber::Update_GameObject(const _float& fTimeDelta)
 	//// FMS 디버깅 임시
 	//if (GetAsyncKeyState('N'))
 	//	Add_Progress(fTimeDelta, 0.5f);
-	//swprintf_s(m_szProgress, L"오이 : %d, %f", m_eCookState, m_fProgress);
+	//swprintf_s(m_szTemp, L"오이 : %d, %f", m_eCookState, m_fProgress);
 	////
 
 	return iExit;
@@ -73,7 +73,7 @@ void CCucumber::Render_GameObject()
 
 	//// FMS 디버깅 임시
 	//_vec2   vPos{ 100.f, 100.f };
-	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szTemp, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
 	////
 
 	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);

--- a/Client/Code/CFish.cpp
+++ b/Client/Code/CFish.cpp
@@ -47,7 +47,7 @@ _int CFish::Update_GameObject(const _float& fTimeDelta)
 	//// FMS 디버깅 임시
 	//if (GetAsyncKeyState('N'))
 	//	Add_Progress(fTimeDelta, 0.5f);
-	//swprintf_s(m_szProgress, L"생선 : %d, %f", m_eCookState, m_fProgress);
+	//swprintf_s(m_szTemp, L"생선 : %d, %f", m_eCookState, m_fProgress);
 	////
 
 	return iExit;
@@ -73,7 +73,7 @@ void CFish::Render_GameObject()
 
 	//// FMS 디버깅 임시
 	//_vec2   vPos{ 100.f, 100.f };
-	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szTemp, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
 	////
 
 	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);

--- a/Client/Code/CIngredient.cpp
+++ b/Client/Code/CIngredient.cpp
@@ -3,15 +3,13 @@
 #include "IState.h"
 
 CIngredient::CIngredient(LPDIRECT3DDEVICE9 pGraphicDev)
-	: CInteract(pGraphicDev), m_eIngredientType(ING_END), m_eCookState(RAW), m_pCurrentState(nullptr), m_fProgress(0.f)
+	: CInteract(pGraphicDev), m_eIngredientType(ING_END), m_eCookState(RAW), m_pCurrentState(nullptr), m_fProgress(0.f), m_bLocked(false)
 {
-	ZeroMemory(m_szProgress, sizeof(m_szProgress));
 }
 
 CIngredient::CIngredient(const CGameObject& rhs)
-	: CInteract(rhs), m_eIngredientType(ING_END), m_eCookState(CS_END), m_pCurrentState(nullptr), m_fProgress(0.f)
+	: CInteract(rhs), m_eIngredientType(ING_END), m_eCookState(CS_END), m_pCurrentState(nullptr), m_fProgress(0.f), m_bLocked(false)
 {
-	ZeroMemory(m_szProgress, sizeof(m_szProgress));
 }
 
 CIngredient::~CIngredient()
@@ -72,9 +70,4 @@ void CIngredient::Free()
 	}
 
 	CInteract::Free();
-}
-
-_bool CIngredient::Get_CanCarry() const
-{
-	return true;
 }

--- a/Client/Code/CInteract.cpp
+++ b/Client/Code/CInteract.cpp
@@ -4,11 +4,13 @@
 CInteract::CInteract(LPDIRECT3DDEVICE9 pGraphicDev)
 	: Engine::CGameObject(pGraphicDev)
 {
+	ZeroMemory(m_szTemp, sizeof(m_szTemp));
 }
 
 CInteract::CInteract(const CGameObject& rhs)
 	: Engine::CGameObject(rhs)
 {
+	ZeroMemory(m_szTemp, sizeof(m_szTemp));
 }
 
 CInteract::~CInteract()

--- a/Client/Code/CLettuce.cpp
+++ b/Client/Code/CLettuce.cpp
@@ -47,7 +47,7 @@ _int CLettuce::Update_GameObject(const _float& fTimeDelta)
 	//// FMS 디버깅 임시
 	//if (GetAsyncKeyState('N'))
 	//	Add_Progress(fTimeDelta, 0.5f);
-	//swprintf_s(m_szProgress, L"양배추 : %d, %f", m_eCookState, m_fProgress);
+	//swprintf_s(m_szTemp, L"양배추 : %d, %f", m_eCookState, m_fProgress);
 	////
 
 	return iExit;
@@ -73,7 +73,7 @@ void CLettuce::Render_GameObject()
 	
 	//// FMS 디버깅 임시
 	//_vec2   vPos{ 100.f, 100.f };
-	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szTemp, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
 	////
 
 	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);

--- a/Client/Code/CPasta.cpp
+++ b/Client/Code/CPasta.cpp
@@ -52,7 +52,7 @@ _int CPasta::Update_GameObject(const _float& fTimeDelta)
 	//// FMS µð¹ö±ë ÀÓ½Ã
 	//if (RAW == m_eCookState && GetAsyncKeyState('B'))
 	//	Set_Progress(1.f);	// Add_Progress(fTimeDelta, 0.5f);
-	//swprintf_s(m_szProgress, L"½Ò : %d, %f", m_eCookState, m_fProgress);
+	//swprintf_s(m_szTemp, L"½Ò : %d, %f", m_eCookState, m_fProgress);
 	////
 
 	return iExit;
@@ -98,7 +98,7 @@ void CPasta::Render_GameObject()
 
 	//// FMS µð¹ö±ë ÀÓ½Ã
 	//_vec2   vPos{ 100.f, 150.f };
-	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szTemp, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
 	////
 
 	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);

--- a/Client/Code/CRice.cpp
+++ b/Client/Code/CRice.cpp
@@ -50,7 +50,7 @@ _int CRice::Update_GameObject(const _float& fTimeDelta)
 	//// FMS µð¹ö±ë ÀÓ½Ã
 	//if (RAW == m_eCookState && GetAsyncKeyState('B'))
 	//	Set_Progress(1.f);//` Add_Progress(fTimeDelta, 0.5f);
-	//swprintf_s(m_szProgress, L"½Ò : %d, %f", m_eCookState, m_fProgress);
+	//swprintf_s(m_szTemp, L"½Ò : %d, %f", m_eCookState, m_fProgress);
 	////
 
 	return iExit;
@@ -80,7 +80,7 @@ void CRice::Render_GameObject()
 
 	//// FMS µð¹ö±ë ÀÓ½Ã
 	//_vec2   vPos{ 100.f, 150.f };
-	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szTemp, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
 	////
 
 	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);

--- a/Client/Code/CSeaweed.cpp
+++ b/Client/Code/CSeaweed.cpp
@@ -47,7 +47,7 @@ _int CSeaweed::Update_GameObject(const _float& fTimeDelta)
 	//// FMS 디버깅 임시
 	//if (GetAsyncKeyState('M'))
 	//	Add_Progress(fTimeDelta, 0.5f);
-	//swprintf_s(m_szProgress, L"다시마 : %d, %f", m_eCookState, m_fProgress);
+	//swprintf_s(m_szTemp, L"다시마 : %d, %f", m_eCookState, m_fProgress);
 	////
 
 	return iExit;
@@ -71,7 +71,7 @@ void CSeaweed::Render_GameObject()
 
 	//// FMS 디버깅 임시
 	//_vec2   vPos{ 100.f, 50.f };
-	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szTemp, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
 	////
 	
 	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);

--- a/Client/Code/CShrimp.cpp
+++ b/Client/Code/CShrimp.cpp
@@ -49,7 +49,7 @@ _int CShrimp::Update_GameObject(const _float& fTimeDelta)
 	//// FMS 디버깅 임시
 	//if (GetAsyncKeyState('N'))
 	//	Add_Progress(fTimeDelta, 0.5f);
-	//swprintf_s(m_szProgress, L"새우 : %d, %f", m_eCookState, m_fProgress);
+	//swprintf_s(m_szTemp, L"새우 : %d, %f", m_eCookState, m_fProgress);
 	////
 
 	return iExit;
@@ -91,7 +91,7 @@ void CShrimp::Render_GameObject()
 
 	//// FMS 디버깅 임시
 	//_vec2   vPos{ 100.f, 100.f };
-	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szTemp, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
 	////
 
 	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);

--- a/Client/Code/CStage.cpp
+++ b/Client/Code/CStage.cpp
@@ -207,11 +207,11 @@ HRESULT CStage::Ready_GameObject_Layer(const _tchar* pLayerTag)
     //if (FAILED(pLayer->Add_GameObject(L"Station_Ingredient", pGameObject)))
     //    return E_FAIL;
 
-    //pGameObject = CChopStation::Create(m_pGraphicDev);
-    //if (nullptr == pGameObject)
-    //    return E_FAIL;
-    //if (FAILED(pLayer->Add_GameObject(L"Station_Chop", pGameObject)))
-    //    return E_FAIL;
+    pGameObject = CChopStation::Create(m_pGraphicDev);
+    if (nullptr == pGameObject)
+        return E_FAIL;
+    if (FAILED(pLayer->Add_GameObject(L"Station_Chop", pGameObject)))
+        return E_FAIL;
 
     //pGameObject = CGasStation::Create(m_pGraphicDev);
     //if (nullptr == pGameObject)

--- a/Client/Code/CTomato.cpp
+++ b/Client/Code/CTomato.cpp
@@ -30,7 +30,9 @@ HRESULT CTomato::Ready_GameObject()
 	m_eIngredientType = TOMATO;
 	m_eCookState = RAW;
 	m_pCurrentState = new IRawState();
-	m_pTransformCom->Set_Pos(4.f, m_pTransformCom->Get_Scale().y + 5.f, 5.f);
+	m_pTransformCom->Set_Pos(4.f, m_pTransformCom->Get_Scale().y * 0.5f, 4.f);
+
+	m_stOpt.bApplyGravity = false;
 
 	CInteractMgr::GetInstance()->Add_List(CInteractMgr::CARRY, this);
 
@@ -49,10 +51,10 @@ _int CTomato::Update_GameObject(const _float& fTimeDelta)
 	//// FMS 디버깅 임시
 	//if (GetAsyncKeyState('N'))
 	//	Add_Progress(fTimeDelta, 0.5f);
-	//swprintf_s(m_szProgress, L"토마토 : %d, %f", m_eCookState, m_fProgress);
+	//swprintf_s(m_szTemp, L"토마토 : %d, %f", m_eCookState, m_fProgress);
 	////
 
-	//swprintf_s(m_szProgress, L"토마토 Ground (I 올리기 / J 내리기) : %d", m_bGround);
+	//swprintf_s(m_szTemp, L"토마토 Ground (I 올리기 / J 내리기) : %d", m_bGround);
 
 	return iExit;
 }
@@ -62,38 +64,38 @@ void CTomato::LateUpdate_GameObject(const _float& fTimeDelta)
 	Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
 
 	//// IPlace 테스트
-	//if (GetAsyncKeyState('I'))
-	//{
-	//	list<CGameObject*>* pListStation = CInteractMgr::GetInstance()->Get_List(CInteractMgr::STATION);
-	//	CGameObject* pStation = nullptr;
+	if (GetAsyncKeyState('I'))
+	{
+		list<CGameObject*>* pListStation = CInteractMgr::GetInstance()->Get_List(CInteractMgr::STATION);
+		CGameObject* pStation = nullptr;
+	
+		if (pListStation)
+			pStation = pListStation->front();
+	
+		if (pStation)
+			dynamic_cast<IPlace*>(pStation)->Set_Place(this, pStation);
+	}
 	//
-	//	if (pListStation)
-	//		pStation = pListStation->front();
-	//
-	//	if (pStation)
-	//		dynamic_cast<IPlace*>(pStation)->Set_Place(this, pStation);
-	//}
-	////
-	//if (GetAsyncKeyState('J'))
-	//{
-	//	list<CGameObject*>* pListStation = CInteractMgr::GetInstance()->Get_List(CInteractMgr::STATION);
-	//	CGameObject* pStation = nullptr;
-	//
-	//	if (pListStation)
-	//		pStation = pListStation->front();
-	//
-	//	CGameObject* pObj = nullptr;
-	//
-	//	if (pStation)
-	//		pObj = dynamic_cast<IPlace*>(pStation)->Get_PlacedItem();
-	//
-	//	if (nullptr == pObj)
-	//		return;
-	//
-	//	dynamic_cast<IPlace*>(pStation)->Set_Empty();
-	//
-	//	dynamic_cast<CTransform*>(pObj->Get_Component(ID_DYNAMIC, L"Com_Transform"))->Set_Pos(4.f, m_pTransformCom->Get_Scale().y + 5.f, 5.f);
-	//}
+	if (GetAsyncKeyState('J'))
+	{
+		list<CGameObject*>* pListStation = CInteractMgr::GetInstance()->Get_List(CInteractMgr::STATION);
+		CGameObject* pStation = nullptr;
+	
+		if (pListStation)
+			pStation = pListStation->front();
+	
+		CGameObject* pObj = nullptr;
+	
+		if (pStation)
+			pObj = dynamic_cast<IPlace*>(pStation)->Get_PlacedItem();
+	
+		if (nullptr == pObj)
+			return;
+	
+		dynamic_cast<IPlace*>(pStation)->Set_Empty();
+	
+		dynamic_cast<CTransform*>(pObj->Get_Component(ID_DYNAMIC, L"Com_Transform"))->Set_Pos(4.f, m_pTransformCom->Get_Scale().y * 0.5f, 4.f);
+	}
 }
 
 void CTomato::Render_GameObject()
@@ -111,7 +113,7 @@ void CTomato::Render_GameObject()
 
 	//// FMS 디버깅 임시
 	//_vec2   vPos{ 100.f, 100.f };
-	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szProgress, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
+	//CFontMgr::GetInstance()->Render_Font(L"Font_Default", m_szTemp, &vPos, D3DXCOLOR(0.f, 0.f, 0.f, 1.f));
 	////
 
 	//m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);

--- a/Client/Header/CChopStation.h
+++ b/Client/Header/CChopStation.h
@@ -10,6 +10,8 @@
 #include "IPlace.h"
 #include "IChop.h"
 
+#include "IPhysics.h"
+
 namespace Engine
 {
 	class CCubeTex;
@@ -17,7 +19,7 @@ namespace Engine
 	class CTexture;
 }
 
-class CChopStation : public CInteract, public IPlace, public IChop
+class CChopStation : public CInteract, public IPlace, public IChop//, public IPhysics
 {
 protected:
 	explicit CChopStation(LPDIRECT3DDEVICE9 pGraphicDev);
@@ -30,23 +32,14 @@ public:
 	virtual			void		LateUpdate_GameObject(const _float& fTimeDelta);
 	virtual			void		Render_GameObject();
 
-	// IChop을(를) 통해 상속됨
-
-	/**
-	* @brief 해당 재료를 썰 수 있는지 판별하는 함수.
-	* @param pIngredient - 썰고자 하는 재료 포인터.
-	* @return true면 썰기 가능, false면 불가능.
-	*/
-	virtual _bool CanChop(CIngredient* pIngredient) const;
-	/**
-	* @brief 해당 재료를 써는 동작을 수행하는 함수.
-	* @param pIngredient - 썰고자 하는 재료 포인터.
-	* @details 실제 썰기 동작을 수행하며, 상태 변경이나 진행도 증가가 포함.
-	*/
-	virtual void Chop(CIngredient* pIngredient);
 
 	// CInteract을(를) 통해 상속됨
 	INTERACTTYPE	Get_InteractType() const override { return CInteract::STATION; }
+
+	// IChop을(를) 통해 상속됨
+	_bool			Enter_Chop() override;
+	void			Update_Chop(const _float& fTimeDelta) override;
+	void			Exit_Chop() override;
 
 private:
 	HRESULT		Add_Component();

--- a/Client/Header/CEmptyStation.h
+++ b/Client/Header/CEmptyStation.h
@@ -44,9 +44,6 @@ public:
 	static CEmptyStation* Create(LPDIRECT3DDEVICE9 pGraphicDev);
 
 private:
-	_tchar					m_szProgress[128];
-
-private:
 	virtual		void		Free();
 
 	// IPlace을(를) 통해 상속됨

--- a/Client/Header/CIngredient.h
+++ b/Client/Header/CIngredient.h
@@ -9,10 +9,9 @@
 #pragma once
 #include "CInteract.h"
 #include "IPhysics.h"
-#include "ICarry.h"
 class IState;
 
-class CIngredient : public CInteract, public IPhysics, public ICarry
+class CIngredient : public CInteract, public IPhysics
 {
 public:
 	/**
@@ -48,14 +47,6 @@ protected:
 	explicit CIngredient(LPDIRECT3DDEVICE9 pGraphicDev);
 	explicit CIngredient(const CGameObject& rhs);
 	virtual ~CIngredient();
-
-public:
-	// ICarry을(를) 통해 상속됨
-	/**
-	* @brief 해당 오브젝트가 현재 들고 이동 가능한 상태인지 확인하는 함수.
-	* @return 이동 가능하면 true, 불가능하면 false.
-	*/
-	virtual		_bool		Get_CanCarry() const override;
 
 public:
 	/**
@@ -100,6 +91,9 @@ public:
 	*/
 	virtual		void		ChangeState(IState* pNextState);
 
+	virtual		void		Set_Lock(_bool bLocked) { m_bLocked = bLocked; }
+	virtual		_bool		Get_Lock() const { return m_bLocked; }
+
 private:
 	virtual		bool		Check_Progress();
 
@@ -109,7 +103,7 @@ protected:
 	IState*					m_pCurrentState;	///< IState* 재료 FMS
 	_float					m_fProgress;	///< 실수형 변수 (재료의 조리 진행도) (0.0f ~ 1.0f 범위) 
 
-	_tchar					m_szProgress[128];	// 디버깅 위해 임시로 사용
+	_bool					m_bLocked;
 
 protected:
 	virtual		void		Free();

--- a/Client/Header/CInteract.h
+++ b/Client/Header/CInteract.h
@@ -39,7 +39,7 @@ public:
 	 * @brief 이 오브젝트가 Ground(바닥)인지 여부를 설정하는 함수.
 	 * @param bGround true로 설정하면 Ground, false로 설정하면 비활성화
 	 */
-	void	set_Ground(_bool bGround) { m_bGround = bGround; }
+	void	Set_Ground(_bool bGround) { m_bGround = bGround; }
 
 	/**
 	 * @brief 이 오브젝트가 어떤 타입인지 반환하는 순수가상함수
@@ -49,6 +49,7 @@ public:
 
 protected:
 	_bool		m_bGround = false;
+	_tchar		m_szTemp[128];	// 디버깅 위해 임시로 사용
 
 protected:
 	virtual		void		Free();

--- a/Client/Header/CLettuceTemp.h
+++ b/Client/Header/CLettuceTemp.h
@@ -16,7 +16,7 @@ namespace Engine
 	class CTexture;
 }
 
-class CLettuceTemp : public CIngredient
+class CLettuceTemp : public CIngredient//, public IPhysics
 {
 protected:
 	explicit CLettuceTemp(LPDIRECT3DDEVICE9 pGraphicDev);

--- a/Client/Header/IChop.h
+++ b/Client/Header/IChop.h
@@ -1,8 +1,8 @@
 /**
-* @file    IChop.h
-* @date    2025-06-29
+* @file    IPlace.h
+* @date    2025-07-03
 * @author  권예지
-* @brief   재료를 썰 수 있는 오브젝트를 위한 인터페이스
+* @brief   공간 위에 오브젝트 (재료) 를 썰 수 있는 인터페이스
 * @details 플레이어가 재료(CIngredient)를 써는 행위를 처리하는 공통 인터페이스.
 */
 #pragma once
@@ -12,16 +12,48 @@ class CIngredient;
 class IChop 
 {
 public:
+    virtual     ~IChop() {}
+
     /**
-    * @brief 해당 재료를 썰 수 있는지 판별하는 함수.
-    * @param pIngredient - 썰고자 하는 재료 포인터.
-    * @return true면 썰기 가능, false면 불가능.
+    * @brief 공간 위에 있는 재료를 썰기 시작하는 함수
+    * @details 공간 위에 재료가 있고, 재료가 썰 수 있는 상태면 썰기 시작
+    * @return true면 썰기 시작, false면 썰기 실패
     */
-	virtual _bool CanChop(CIngredient* pIngredient) const = 0;
+    virtual     _bool   Enter_Chop() = 0;
+
     /**
-    * @brief 해당 재료를 써는 동작을 수행하는 함수.
-    * @param pIngredient - 썰고자 하는 재료 포인터.
-    * @details 실제 썰기 동작을 수행하며, 상태 변경이나 진행도 증가가 포함.
+    * @brief 썰기 중단 함수
+    * @details 현재 썰기 진행을 중단하고 내부 상태를 false로 설정
     */
-	virtual void Chop(CIngredient* pIngredient) = 0;
+    virtual     void    Pause_Chop() { m_bChop = false; }
+
+    _bool       Get_Chop() const { return m_bChop; }
+
+protected:
+    /**
+    * @brief 썰기 진행 업데이트 함수
+    * @details 썰기 중일 때 시간에 따라 진행도를 추가
+    * @param fTimeDelta 프레임 시간 (초 단위)
+    */
+	virtual     void    Update_Chop(const _float& fTimeDelta) = 0;
+
+    /**
+    * @brief 썰기 종료 처리 함수
+    * @details 썰기 완료 시 재료 상태 변경 등 마무리 작업 수행
+    */
+    virtual     void    Exit_Chop() = 0;
+
+    void        Set_Chop(_bool bChop) { m_bChop = bChop; }
+    void        Set_Progress(const _float& fAdd) { m_fProgress = fAdd; }
+    void        Add_Progress(const _float& fTimeDelta, const _float& fAdd) { m_fProgress += fAdd * fTimeDelta; }
+
+    _float      Get_Progress() const { return m_fProgress; }
+
+private:
+    _bool       m_bChop = false;        ///< 현재 썰기 중 여부
+    _float      m_fProgress = 0.f;      ///< 썰기 진행도 (0.0f ~ 1.0f)
 };
+
+// class IProcess 순수 가상함수로 만들고
+// IProcess를 상속 받는 IChop, ICook 만들엇
+// 다른데서 IProcess로 다이나믹 캐스팅해서 쓸 수 있게 수정하자

--- a/Client/Header/IPlace.h
+++ b/Client/Header/IPlace.h
@@ -10,11 +10,12 @@
 #include "Engine_Define.h"
 #include "ICarry.h"
 #include "CTransform.h"
+#include "CIngredient.h"
 
 class IPlace
 {
 public:
-	virtual ~IPlace() {}
+	virtual		~IPlace() {}
 
 	/**
 	* @brief 해당 공간 위에 물건을 올리는 함수
@@ -41,8 +42,8 @@ public:
 		vPlaceScale = pPlaceTransform->Get_Scale();
 		vItemScale = pItemTransform->Get_Scale();
 
-		dynamic_cast<CInteract*>(pItem)->set_Ground(true);
-		pItemTransform->Set_Pos(vPlacePos.x, vPlacePos.y + vPlaceScale.y + vItemScale.y, vPlacePos.z);
+		dynamic_cast<CInteract*>(pItem)->Set_Ground(true);
+		pItemTransform->Set_Pos(vPlacePos.x, vPlacePos.y + vPlaceScale.y * 0.5f + vItemScale.y * 0.5f, vPlacePos.z);
 
 		m_bFull = true;
 		m_pPlacedItem = pItem;
@@ -65,7 +66,10 @@ public:
 		if (nullptr == m_pPlacedItem)
 			return nullptr;
 
-		dynamic_cast<CInteract*>(m_pPlacedItem)->set_Ground(false);
+		if (dynamic_cast<CIngredient*>(m_pPlacedItem)->Get_Lock())
+			return nullptr;
+
+		dynamic_cast<CInteract*>(m_pPlacedItem)->Set_Ground(false);
 		CGameObject* pItem = m_pPlacedItem;
 
 		Set_Empty();
@@ -89,6 +93,9 @@ private:
 	* @return true면 올릴 수 있음, false면 불가능
 	*/
 	virtual _bool Get_CanPlace(CGameObject* pItem) = 0;
+
+protected:
+	CGameObject* const Get_Item() { return m_pPlacedItem; }
 
 protected:
 	_bool			m_bFull = false;			///< 불자료형 변수 (현재 공간이 가득 찼는지 여부) (true = 공간 사용 중, false = 비어있음)

--- a/Client/Include/CEmptyStationTemp.h
+++ b/Client/Include/CEmptyStationTemp.h
@@ -17,7 +17,7 @@ namespace Engine
 	class CTexture;
 }
 
-class CEmptyStationTemp : public CInteract, public IPlace, public IPhysics
+class CEmptyStationTemp : public CInteract, public IPlace//, public IPhysics
 {
 protected:
 	explicit CEmptyStationTemp(LPDIRECT3DDEVICE9 pGraphicDev);


### PR DESCRIPTION
- IChopStation(도마)가 IChop 상속, 캐스팅 후 썰기 관련 함수 호출.
- 조리 진행도를 재료에서 IChop으로 이동 (ICook도 추후 진행할 때 ICook이 진행도를 가지도록 수정할 예정)
- 썰고 있는 상태에서는 재료를 이동시킬 수 없도록 구현
- 현재 IChop으로 캐스팅해서 함수를 호출할 수 있는데, 추후 IProcess 추가해서 (IChop, ICook이 IProcess를 상속 받음) IProcess로 캐스팅해서 함수 호출할 수 있도록 수정할 예정.