### PR TITLE
[Fix] : Stage에 include 중복 제거

### DIFF
--- a/Client/Code/CStage.cpp
+++ b/Client/Code/CStage.cpp
@@ -34,7 +34,6 @@
 #include "CTrashStation.h"
 #include "CFloor.h"
 #include "CInvisibleStation.h"
-#include "CCleanPlateStation.h"
 
 #include "CFakePlayer.h"
 #include "CLettuceTemp.h"
@@ -49,10 +48,6 @@
 
 #include "CInteractMgr.h"
 #include "CFontMgr.h"
-#include "CDirtyPlateStation.h"
-#include <CSinkStation.h>
-#include <CTrashStation.h>
-#include <CServingStation.h>
 #include "CUtil.h"
 #include "CInGameSystem.h"
 


### PR DESCRIPTION
- CStage.cpp에 환경 오브젝트 include 중복 제거