### PR TITLE
[Fix] : Delete_GameObject에 주소값 넘기게 수정

### DIFF
--- a/Client/Code/CPlate.cpp
+++ b/Client/Code/CPlate.cpp
@@ -123,7 +123,7 @@ _bool CPlate::Set_Place(CGameObject* pItem, CGameObject* pPlace)
 
 	// 재료를 오브젝트 풀에 반환
 	CObjectPoolMgr::GetInstance()->Return_Object(pIngredient->Get_SelfId(), pIngredient);
-	CManagement::GetInstance()->Delete_GameObject(L"GameObject_Layer", pIngredient->Get_SelfId());
+	CManagement::GetInstance()->Delete_GameObject(L"GameObject_Layer", pIngredient->Get_SelfId(), pItem);
 	
 	// pItem이 냄비나 후라이팬일 경우 비워줌
 	if (IPlace* pPlace = dynamic_cast<IPlace*>(pItem))

--- a/Client/Code/CSeaweed.cpp
+++ b/Client/Code/CSeaweed.cpp
@@ -31,8 +31,8 @@ HRESULT CSeaweed::Ready_GameObject()
 	m_eCookState = RAW;
 	m_pCurrentState = new IRawState();
 
-	m_pTransformCom->Set_Pos(2.f, m_pTransformCom->Get_Scale().y, 2.f);
-	//m_pTransformCom->Set_Pos((_float)(rand() % 3) + 2, m_pTransformCom->Get_Scale().y, (_float)(rand() % 3) + 2);
+	//m_pTransformCom->Set_Pos(2.f, m_pTransformCom->Get_Scale().y, 2.f);
+	m_pTransformCom->Set_Pos((_float)(rand() % 3) + 2, m_pTransformCom->Get_Scale().y, (_float)(rand() % 3) + 2);
 
 	m_stOpt.bApplyGravity = true;
 	m_stOpt.bApplyRolling = true;

--- a/Client/Code/CServingStation.cpp
+++ b/Client/Code/CServingStation.cpp
@@ -83,7 +83,7 @@ _bool CServingStation::Set_Place(CGameObject* pItem, CGameObject* pPlace)
 
 	// 접시를 오브젝트 풀에 반환
 	CObjectPoolMgr::GetInstance()->Return_Object(pItem->Get_SelfId(), pItem);
-	CManagement::GetInstance()->Delete_GameObject(L"GameObject_Layer", pItem->Get_SelfId());
+	CManagement::GetInstance()->Delete_GameObject(L"GameObject_Layer", pItem->Get_SelfId(), pItem);
 
 	return true;
 }

--- a/Client/Code/CStage.cpp
+++ b/Client/Code/CStage.cpp
@@ -34,7 +34,6 @@
 #include "CTrashStation.h"
 #include "CFloor.h"
 #include "CInvisibleStation.h"
-#include "CCleanPlateStation.h"
 
 #include "CFakePlayer.h"
 #include "CLettuceTemp.h"
@@ -49,10 +48,6 @@
 
 #include "CInteractMgr.h"
 #include "CFontMgr.h"
-#include "CDirtyPlateStation.h"
-#include <CSinkStation.h>
-#include <CTrashStation.h>
-#include <CServingStation.h>
 #include "CUtil.h"
 #include "CInGameSystem.h"
 
@@ -165,6 +160,18 @@ HRESULT CStage::Ready_GameObject_Layer(const _tchar* pLayerTag)
         return E_FAIL;
 
     // Ingredient_Object
+    pGameObject = CSeaweed::Create(m_pGraphicDev);
+    if (nullptr == pGameObject)
+        return E_FAIL;
+    if (FAILED(pLayer->Add_GameObject(L"Ingredient_Seaweed", pGameObject)))
+        return E_FAIL;
+
+    pGameObject = CSeaweed::Create(m_pGraphicDev);
+    if (nullptr == pGameObject)
+        return E_FAIL;
+    if (FAILED(pLayer->Add_GameObject(L"Ingredient_Seaweed", pGameObject)))
+        return E_FAIL;
+
     pGameObject = CSeaweed::Create(m_pGraphicDev);
     if (nullptr == pGameObject)
         return E_FAIL;

--- a/Client/Code/CTrashStation.cpp
+++ b/Client/Code/CTrashStation.cpp
@@ -85,7 +85,7 @@ _bool CTrashStation::Set_Place(CGameObject* pItem, CGameObject* pPlace)
 	{	
 		// 재료일 경우 ObjectPool에 반환
 		CObjectPoolMgr::GetInstance()->Return_Object(pInteract->Get_SelfId(), pInteract);
-		CManagement::GetInstance()->Delete_GameObject(L"GameObject_Layer", pInteract->Get_SelfId());
+		CManagement::GetInstance()->Delete_GameObject(L"GameObject_Layer", pInteract->Get_SelfId(), pItem);
 	}
 	else if (CInteract::PLATE == eInteractType)
 	{

--- a/Engine/Code/CLayer.cpp
+++ b/Engine/Code/CLayer.cpp
@@ -91,14 +91,24 @@ HRESULT CLayer::Add_GameObject(const _tchar* pObjTag, CGameObject* pGameObject, 
 	return hr;
 }
 
-HRESULT CLayer::Delete_GameObject(const _tchar* _pObjTag)
+HRESULT CLayer::Delete_GameObject(const _tchar* _pObjTag, const CGameObject* _pObj)
 {
-	auto	iter = find_if(m_mapObject.begin(), m_mapObject.end(), CTag_Finder(_pObjTag));
+	//auto	iter = find_if(m_mapObject.begin(), m_mapObject.end(), CTag_Finder(_pObjTag));
+	//
+	//if (iter == m_mapObject.end())
+	//	return E_FAIL;
+	//
+	//m_mapObject.erase(iter);
 
-	if (iter == m_mapObject.end())
-		return E_FAIL;
+	auto range = m_mapObject.equal_range(_pObjTag);
 
-	m_mapObject.erase(iter);
+	for (auto it = range.first; it != range.second;)
+	{
+		if (it->second == _pObj)
+			it = m_mapObject.erase(it);
+		else
+			++it;
+	}
 
 	return S_OK;
 }

--- a/Engine/Code/CManagement.cpp
+++ b/Engine/Code/CManagement.cpp
@@ -28,12 +28,12 @@ CGameObject* CManagement::Get_GameObject(const _tchar* _pLayerTag, const _tchar*
     return m_pScene->Get_GameObject(_pLayerTag, _pObjTag);
 }
 
-HRESULT CManagement::Delete_GameObject(const _tchar* _pLayerTag, const _tchar* _pObjTag)
+HRESULT CManagement::Delete_GameObject(const _tchar* _pLayerTag, const _tchar* _pObjTag, const CGameObject* pObj)
 {
     if (!m_pScene)
         return E_FAIL;
 
-    m_pScene->Delete_GameObject(_pLayerTag, _pObjTag);
+    m_pScene->Delete_GameObject(_pLayerTag, _pObjTag, pObj);
 
     return S_OK;
 }

--- a/Engine/Code/CScene.cpp
+++ b/Engine/Code/CScene.cpp
@@ -29,14 +29,14 @@ CGameObject* CScene::Get_GameObject(const _tchar* _pLayerTag, const _tchar* _pOb
     return iter->second->Get_GameObject(_pObjTag);
 }
 
-HRESULT CScene::Delete_GameObject(const _tchar* _pLayerTag, const _tchar* _pObjTag)
+HRESULT CScene::Delete_GameObject(const _tchar* _pLayerTag, const _tchar* _pObjTag, const CGameObject* _pObj)
 {
     auto    iter = find_if(m_mapLayer.begin(), m_mapLayer.end(), CTag_Finder(_pLayerTag));
 
     if (iter == m_mapLayer.end())
         return E_FAIL;
 
-    iter->second->Delete_GameObject(_pObjTag);
+    iter->second->Delete_GameObject(_pObjTag, _pObj);
 
     return S_OK;
 }

--- a/Engine/Header/CLayer.h
+++ b/Engine/Header/CLayer.h
@@ -15,7 +15,7 @@ public:
 	CGameObject*	Get_GameObject(const _tchar* _pObjTag);
 	HRESULT			Add_GameObject(const _tchar* pObjTag, CGameObject* pGameObject);
 	HRESULT			Add_GameObject(const _tchar* pObjTag, CGameObject* pGameObject, LPDIRECT3DDEVICE9 pGraphicDev);
-	HRESULT			Delete_GameObject(const _tchar* _pObjTag);
+	HRESULT			Delete_GameObject(const _tchar* _pObjTag, const CGameObject* _pObj);
 public:
 	HRESULT			Ready_Layer();
 	_int			Update_Layer(const _float& fTimeDelta);

--- a/Engine/Header/CManagement.h
+++ b/Engine/Header/CManagement.h
@@ -26,7 +26,8 @@ public:
 
 	HRESULT Delete_GameObject(
 		const _tchar* _pLayerTag,
-		const _tchar* _pObjTag
+		const _tchar* _pObjTag,
+		const CGameObject* pObj
 	);
 
 public:

--- a/Engine/Header/CScene.h
+++ b/Engine/Header/CScene.h
@@ -24,7 +24,8 @@ public:
 
 	HRESULT Delete_GameObject(
 		const _tchar* _pLayerTag,
-		const _tchar* _pObjTag
+		const _tchar* _pObjTag,
+		const CGameObject* _pObj
 	);
 
 public:

--- a/Reference/Header/CLayer.h
+++ b/Reference/Header/CLayer.h
@@ -15,7 +15,7 @@ public:
 	CGameObject*	Get_GameObject(const _tchar* _pObjTag);
 	HRESULT			Add_GameObject(const _tchar* pObjTag, CGameObject* pGameObject);
 	HRESULT			Add_GameObject(const _tchar* pObjTag, CGameObject* pGameObject, LPDIRECT3DDEVICE9 pGraphicDev);
-	HRESULT			Delete_GameObject(const _tchar* _pObjTag);
+	HRESULT			Delete_GameObject(const _tchar* _pObjTag, const CGameObject* _pObj);
 public:
 	HRESULT			Ready_Layer();
 	_int			Update_Layer(const _float& fTimeDelta);

--- a/Reference/Header/CManagement.h
+++ b/Reference/Header/CManagement.h
@@ -26,7 +26,8 @@ public:
 
 	HRESULT Delete_GameObject(
 		const _tchar* _pLayerTag,
-		const _tchar* _pObjTag
+		const _tchar* _pObjTag,
+		const CGameObject* pObj
 	);
 
 public:

--- a/Reference/Header/CScene.h
+++ b/Reference/Header/CScene.h
@@ -24,7 +24,8 @@ public:
 
 	HRESULT Delete_GameObject(
 		const _tchar* _pLayerTag,
-		const _tchar* _pObjTag
+		const _tchar* _pObjTag,
+		const CGameObject* _pObj
 	);
 
 public:


### PR DESCRIPTION
- Delete_GameObject에 매개변수로 주소값을 넣어서 중복 태그 중에서 해당 주소값을 가진 게임 오브젝트를 멀티맵에서 지우도록 수정
- CStage.cpp에 include 중복 제거