### PR TITLE
[Feat] : 인게임 벽 2종, 데코 10종 추가

### DIFF
--- a/Client/Code/CBamboo.cpp
+++ b/Client/Code/CBamboo.cpp
@@ -91,7 +91,7 @@ HRESULT CBamboo::Add_Component()
         return E_FAIL;
     m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
 
-    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Bamboo"));
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_DecoTexture_Bamboo"));
     if (nullptr == pComponent)
         return E_FAIL;
     m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });

--- a/Client/Code/CBamboo.cpp
+++ b/Client/Code/CBamboo.cpp
@@ -1,0 +1,145 @@
+#include "pch.h"
+#include "CBamboo.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "CManagement.h"
+#include "CCamera.h"
+
+CBamboo::CBamboo(LPDIRECT3DDEVICE9 pGraphicDev)
+    : Engine::CGameObject(pGraphicDev), m_iFrame(0)
+{
+}
+
+CBamboo::CBamboo(const CGameObject& rhs)
+    : Engine::CGameObject(rhs), m_iFrame(0)
+{
+}
+
+CBamboo::~CBamboo()
+{
+}
+
+HRESULT CBamboo::Ready_GameObject()
+{
+    if (FAILED(Add_Component()))
+        return E_FAIL;
+
+    m_iFrame = rand() % 4;
+
+    return S_OK;
+}
+
+_int CBamboo::Update_GameObject(const _float& fTimeDelta)
+{
+    _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+    BillBoard();
+
+    CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+    return iExit;
+}
+
+void CBamboo::LateUpdate_GameObject(const _float& fTimeDelta)
+{
+    Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
+
+    _vec3 vPos;
+    m_pTransformCom->Get_Info(INFO_POS, &vPos);
+    Engine::CGameObject::Compute_ViewZ(&vPos);
+}
+
+void CBamboo::Render_GameObject()
+{
+    m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+    m_pTextureCom->Set_Texture(m_iFrame);
+
+    if (FAILED(Engine::CGameObject::Set_Material()))
+        return;
+
+    m_pBufferCom->Render_Buffer();
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+}
+
+void CBamboo::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+{
+    if (m_pTransformCom)
+    {
+        MSG_BOX("Bamboo Scale Set Failed");
+        return;
+    }
+
+    _vec3 vScale = { fX, fY, fZ };
+    m_pTransformCom->Set_Scale(vScale);
+}
+
+HRESULT CBamboo::Add_Component()
+{
+    CComponent* pComponent = nullptr;
+
+    pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+    pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Bamboo"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
+
+    return S_OK;
+}
+
+void CBamboo::BillBoard()
+{
+    _matrix		matWorld, matView, matBill;
+
+    m_pTransformCom->Get_World(&matWorld);
+    CGameObject* pCamera = CManagement::GetInstance()->Get_GameObject(L"Environment_Layer", L"DynamicCamera");
+    matView = *dynamic_cast<CCamera*>(pCamera)->Get_View();
+    D3DXMatrixIdentity(&matBill);
+
+    matBill._11 = matView._11;
+    matBill._12 = matView._12;
+    matBill._13 = matView._13;
+    matBill._21 = matView._21;
+    matBill._22 = matView._22;
+    matBill._23 = matView._23;
+    matBill._31 = matView._31;
+    matBill._32 = matView._32;
+    matBill._33 = matView._33;
+
+    D3DXMatrixInverse(&matBill, 0, &matBill);
+
+    matWorld = matBill * matWorld;
+
+    m_pTransformCom->Set_World(&matWorld);
+}
+
+CBamboo* CBamboo::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+{
+    CBamboo* pBamboo = new CBamboo(pGraphicDev);
+
+    if (FAILED(pBamboo->Ready_GameObject()))
+    {
+        Safe_Release(pBamboo);
+        MSG_BOX("Bamboo Create Failed");
+        return nullptr;
+    }
+
+    return pBamboo;
+}
+
+void CBamboo::Free()
+{
+    Engine::CGameObject::Free();
+}

--- a/Client/Code/CBarrier.cpp
+++ b/Client/Code/CBarrier.cpp
@@ -1,34 +1,34 @@
 #include "pch.h"
-#include "CWoodWall.h"
+#include "CBarrier.h"
 #include "CProtoMgr.h"
 #include "CRenderer.h"
 
-CWoodWall::CWoodWall(LPDIRECT3DDEVICE9 pGraphicDev)
+CBarrier::CBarrier(LPDIRECT3DDEVICE9 pGraphicDev)
     : CGameObject(pGraphicDev)
 {
 }
 
-CWoodWall::CWoodWall(const CGameObject& rhs)
+CBarrier::CBarrier(const CGameObject& rhs)
     : CGameObject(rhs)
 {
 }
 
-CWoodWall::~CWoodWall()
+CBarrier::~CBarrier()
 {
 }
 
-HRESULT CWoodWall::Ready_GameObject()
+HRESULT CBarrier::Ready_GameObject()
 {
     if (FAILED(Add_Component()))
         return E_FAIL;
 
     m_pTransformCom->Set_Scale({ 3.f, 2.f, 0.5f });
-    m_pTransformCom->Set_Pos(1.5f, 1.f, 0.f);
+    m_pTransformCom->Set_Pos(1.5f, -1.f, 0.f);
 
     return S_OK;
 }
 
-_int CWoodWall::Update_GameObject(const _float& fTimeDelta)
+_int CBarrier::Update_GameObject(const _float& fTimeDelta)
 {
     _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
 
@@ -37,14 +37,14 @@ _int CWoodWall::Update_GameObject(const _float& fTimeDelta)
     return iExit;
 }
 
-void CWoodWall::LateUpdate_GameObject(const _float& fTimeDelta)
+void CBarrier::LateUpdate_GameObject(const _float& fTimeDelta)
 {
     Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
 
     return;
 }
 
-void CWoodWall::Render_GameObject()
+void CBarrier::Render_GameObject()
 {
     m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
 
@@ -56,11 +56,11 @@ void CWoodWall::Render_GameObject()
     m_pBufferCom->Render_Buffer();
 }
 
-void CWoodWall::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+void CBarrier::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
 {
     if (m_pTransformCom)
     {
-        MSG_BOX("WoodWall Scale Set Failed");
+        MSG_BOX("Barrier Scale Set Failed");
         return;
     }
 
@@ -68,7 +68,7 @@ void CWoodWall::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
     m_pTransformCom->Set_Scale(vScale);
 }
 
-HRESULT CWoodWall::Add_Component()
+HRESULT CBarrier::Add_Component()
 {
     CComponent* pComponent = nullptr;
 
@@ -82,7 +82,7 @@ HRESULT CWoodWall::Add_Component()
         return E_FAIL;
     m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
 
-    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_EnvironmentTexture_Wall_Wood"));
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_EnvironmentTexture_Wall_Barrier"));
     if (nullptr == pComponent)
         return E_FAIL;
     m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
@@ -90,21 +90,21 @@ HRESULT CWoodWall::Add_Component()
     return S_OK;
 }
 
-CWoodWall* CWoodWall::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+CBarrier* CBarrier::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 {
-    CWoodWall* pWoodWall = new CWoodWall(pGraphicDev);
+    CBarrier* pBarrier = new CBarrier(pGraphicDev);
 
-    if (FAILED(pWoodWall->Ready_GameObject()))
+    if (FAILED(pBarrier->Ready_GameObject()))
     {
-        Safe_Release(pWoodWall);
-        MSG_BOX("Wall_wood Create Failed");
+        Safe_Release(pBarrier);
+        MSG_BOX("Wall_Barrier Create Failed");
         return nullptr;
     }
 
-    return pWoodWall;
+    return pBarrier;
 }
 
-void CWoodWall::Free()
+void CBarrier::Free()
 {
     Engine::CGameObject::Free();
 }

--- a/Client/Code/CBasket.cpp
+++ b/Client/Code/CBasket.cpp
@@ -1,34 +1,34 @@
 #include "pch.h"
-#include "CWoodWall.h"
+#include "CBasket.h"
 #include "CProtoMgr.h"
 #include "CRenderer.h"
 
-CWoodWall::CWoodWall(LPDIRECT3DDEVICE9 pGraphicDev)
+CBasket::CBasket(LPDIRECT3DDEVICE9 pGraphicDev)
     : CGameObject(pGraphicDev)
 {
 }
 
-CWoodWall::CWoodWall(const CGameObject& rhs)
+CBasket::CBasket(const CGameObject& rhs)
     : CGameObject(rhs)
 {
 }
 
-CWoodWall::~CWoodWall()
+CBasket::~CBasket()
 {
 }
 
-HRESULT CWoodWall::Ready_GameObject()
+HRESULT CBasket::Ready_GameObject()
 {
     if (FAILED(Add_Component()))
         return E_FAIL;
 
-    m_pTransformCom->Set_Scale({ 3.f, 2.f, 0.5f });
-    m_pTransformCom->Set_Pos(1.5f, 1.f, 0.f);
+    m_pTransformCom->Set_Scale({ 3.f, 1.f, 0.5f });
+    m_pTransformCom->Set_Pos(1.5f, 0.5f, 0.f);
 
     return S_OK;
 }
 
-_int CWoodWall::Update_GameObject(const _float& fTimeDelta)
+_int CBasket::Update_GameObject(const _float& fTimeDelta)
 {
     _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
 
@@ -37,14 +37,14 @@ _int CWoodWall::Update_GameObject(const _float& fTimeDelta)
     return iExit;
 }
 
-void CWoodWall::LateUpdate_GameObject(const _float& fTimeDelta)
+void CBasket::LateUpdate_GameObject(const _float& fTimeDelta)
 {
     Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
 
     return;
 }
 
-void CWoodWall::Render_GameObject()
+void CBasket::Render_GameObject()
 {
     m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
 
@@ -56,11 +56,11 @@ void CWoodWall::Render_GameObject()
     m_pBufferCom->Render_Buffer();
 }
 
-void CWoodWall::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+void CBasket::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
 {
     if (m_pTransformCom)
     {
-        MSG_BOX("WoodWall Scale Set Failed");
+        MSG_BOX("Basket Scale Set Failed");
         return;
     }
 
@@ -68,7 +68,7 @@ void CWoodWall::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
     m_pTransformCom->Set_Scale(vScale);
 }
 
-HRESULT CWoodWall::Add_Component()
+HRESULT CBasket::Add_Component()
 {
     CComponent* pComponent = nullptr;
 
@@ -82,7 +82,7 @@ HRESULT CWoodWall::Add_Component()
         return E_FAIL;
     m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
 
-    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_EnvironmentTexture_Wall_Wood"));
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_EnvironmentTexture_Wall_Basket"));
     if (nullptr == pComponent)
         return E_FAIL;
     m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
@@ -90,21 +90,21 @@ HRESULT CWoodWall::Add_Component()
     return S_OK;
 }
 
-CWoodWall* CWoodWall::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+CBasket* CBasket::Create(LPDIRECT3DDEVICE9 pGraphicDev)
 {
-    CWoodWall* pWoodWall = new CWoodWall(pGraphicDev);
+    CBasket* pBasket = new CBasket(pGraphicDev);
 
-    if (FAILED(pWoodWall->Ready_GameObject()))
+    if (FAILED(pBasket->Ready_GameObject()))
     {
-        Safe_Release(pWoodWall);
-        MSG_BOX("Wall_wood Create Failed");
+        Safe_Release(pBasket);
+        MSG_BOX("Wall_basket Create Failed");
         return nullptr;
     }
 
-    return pWoodWall;
+    return pBasket;
 }
 
-void CWoodWall::Free()
+void CBasket::Free()
 {
     Engine::CGameObject::Free();
 }

--- a/Client/Code/CCar.cpp
+++ b/Client/Code/CCar.cpp
@@ -1,0 +1,117 @@
+#include "pch.h"
+#include "CCar.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "CManagement.h"
+#include "CCamera.h"
+
+CCar::CCar(LPDIRECT3DDEVICE9 pGraphicDev)
+    : Engine::CGameObject(pGraphicDev), m_iFrame(0)
+{
+}
+
+CCar::CCar(const CGameObject& rhs)
+    : Engine::CGameObject(rhs), m_iFrame(0)
+{
+}
+
+CCar::~CCar()
+{
+}
+
+HRESULT CCar::Ready_GameObject()
+{
+    if (FAILED(Add_Component()))
+        return E_FAIL;
+
+    m_iFrame = rand() % 4;
+
+    return S_OK;
+}
+
+_int CCar::Update_GameObject(const _float& fTimeDelta)
+{
+    _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+    CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+    return iExit;
+}
+
+void CCar::LateUpdate_GameObject(const _float& fTimeDelta)
+{
+    Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
+
+    _vec3 vPos;
+    m_pTransformCom->Get_Info(INFO_POS, &vPos);
+    Engine::CGameObject::Compute_ViewZ(&vPos);
+}
+
+void CCar::Render_GameObject()
+{
+    m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+    m_pTextureCom->Set_Texture(m_iFrame);
+
+    if (FAILED(Engine::CGameObject::Set_Material()))
+        return;
+
+    m_pBufferCom->Render_Buffer();
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+}
+
+void CCar::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+{
+    if (m_pTransformCom)
+    {
+        MSG_BOX("Car Scale Set Failed");
+        return;
+    }
+
+    _vec3 vScale = { fX, fY, fZ };
+    m_pTransformCom->Set_Scale(vScale);
+}
+
+HRESULT CCar::Add_Component()
+{
+    CComponent* pComponent = nullptr;
+
+    pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTileTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTileTex"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+    pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Car"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
+
+    return S_OK;
+}
+
+CCar* CCar::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+{
+    CCar* pCar = new CCar(pGraphicDev);
+
+    if (FAILED(pCar->Ready_GameObject()))
+    {
+        Safe_Release(pCar);
+        MSG_BOX("Car Create Failed");
+        return nullptr;
+    }
+
+    return pCar;
+}
+
+void CCar::Free()
+{
+    Engine::CGameObject::Free();
+}

--- a/Client/Code/CCar.cpp
+++ b/Client/Code/CCar.cpp
@@ -89,7 +89,7 @@ HRESULT CCar::Add_Component()
         return E_FAIL;
     m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
 
-    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Car"));
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_DecoTexture_Car"));
     if (nullptr == pComponent)
         return E_FAIL;
     m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });

--- a/Client/Code/CCherryTree.cpp
+++ b/Client/Code/CCherryTree.cpp
@@ -1,0 +1,145 @@
+#include "pch.h"
+#include "CCherryTree.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "CManagement.h"
+#include "CCamera.h"
+
+CCherryTree::CCherryTree(LPDIRECT3DDEVICE9 pGraphicDev)
+    : Engine::CGameObject(pGraphicDev), m_iFrame(0)
+{
+}
+
+CCherryTree::CCherryTree(const CGameObject& rhs)
+    : Engine::CGameObject(rhs), m_iFrame(0)
+{
+}
+
+CCherryTree::~CCherryTree()
+{
+}
+
+HRESULT CCherryTree::Ready_GameObject()
+{
+    if (FAILED(Add_Component()))
+        return E_FAIL;
+
+    m_iFrame = rand() % 12;
+
+    return S_OK;
+}
+
+_int CCherryTree::Update_GameObject(const _float& fTimeDelta)
+{
+    _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+    BillBoard();
+
+    CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+    return iExit;
+}
+
+void CCherryTree::LateUpdate_GameObject(const _float& fTimeDelta)
+{
+    Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
+
+    _vec3 vPos;
+    m_pTransformCom->Get_Info(INFO_POS, &vPos);
+    Engine::CGameObject::Compute_ViewZ(&vPos);
+}
+
+void CCherryTree::Render_GameObject()
+{
+    m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+    m_pTextureCom->Set_Texture(m_iFrame);
+
+    if (FAILED(Engine::CGameObject::Set_Material()))
+        return;
+
+    m_pBufferCom->Render_Buffer();
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+}
+
+void CCherryTree::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+{
+    if (m_pTransformCom)
+    {
+        MSG_BOX("CherryTree Scale Set Failed");
+        return;
+    }
+
+    _vec3 vScale = { fX, fY, fZ };
+    m_pTransformCom->Set_Scale(vScale);
+}
+
+HRESULT CCherryTree::Add_Component()
+{
+    CComponent* pComponent = nullptr;
+
+    pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+    pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_CherryTree"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
+
+    return S_OK;
+}
+
+void CCherryTree::BillBoard()
+{
+    _matrix		matWorld, matView, matBill;
+
+    m_pTransformCom->Get_World(&matWorld);
+    CGameObject* pCamera = CManagement::GetInstance()->Get_GameObject(L"Environment_Layer", L"DynamicCamera");
+    matView = *dynamic_cast<CCamera*>(pCamera)->Get_View();
+    D3DXMatrixIdentity(&matBill);
+
+    matBill._11 = matView._11;
+    matBill._12 = matView._12;
+    matBill._13 = matView._13;
+    matBill._21 = matView._21;
+    matBill._22 = matView._22;
+    matBill._23 = matView._23;
+    matBill._31 = matView._31;
+    matBill._32 = matView._32;
+    matBill._33 = matView._33;
+
+    D3DXMatrixInverse(&matBill, 0, &matBill);
+
+    matWorld = matBill * matWorld;
+
+    m_pTransformCom->Set_World(&matWorld);
+}
+
+CCherryTree* CCherryTree::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+{
+    CCherryTree* pCherryTree = new CCherryTree(pGraphicDev);
+
+    if (FAILED(pCherryTree->Ready_GameObject()))
+    {
+        Safe_Release(pCherryTree);
+        MSG_BOX("CherryTree Create Failed");
+        return nullptr;
+    }
+
+    return pCherryTree;
+}
+
+void CCherryTree::Free()
+{
+    Engine::CGameObject::Free();
+}

--- a/Client/Code/CCherryTree.cpp
+++ b/Client/Code/CCherryTree.cpp
@@ -91,7 +91,7 @@ HRESULT CCherryTree::Add_Component()
         return E_FAIL;
     m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
 
-    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_CherryTree"));
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_DecoTexture_CherryTree"));
     if (nullptr == pComponent)
         return E_FAIL;
     m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });

--- a/Client/Code/CCone.cpp
+++ b/Client/Code/CCone.cpp
@@ -89,7 +89,7 @@ HRESULT CCone::Add_Component()
         return E_FAIL;
     m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
 
-    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Cone"));
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_DecoTexture_Cone"));
     if (nullptr == pComponent)
         return E_FAIL;
     m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });

--- a/Client/Code/CCone.cpp
+++ b/Client/Code/CCone.cpp
@@ -1,0 +1,143 @@
+#include "pch.h"
+#include "CCone.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "CManagement.h"
+#include "CCamera.h"
+
+CCone::CCone(LPDIRECT3DDEVICE9 pGraphicDev)
+    : Engine::CGameObject(pGraphicDev)
+{
+}
+
+CCone::CCone(const CGameObject& rhs)
+    : Engine::CGameObject(rhs)
+{
+}
+
+CCone::~CCone()
+{
+}
+
+HRESULT CCone::Ready_GameObject()
+{
+    if (FAILED(Add_Component()))
+        return E_FAIL;
+
+    return S_OK;
+}
+
+_int CCone::Update_GameObject(const _float& fTimeDelta)
+{
+    _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+    BillBoard();
+
+    CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+    return iExit;
+}
+
+void CCone::LateUpdate_GameObject(const _float& fTimeDelta)
+{
+    Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
+
+    _vec3 vPos;
+    m_pTransformCom->Get_Info(INFO_POS, &vPos);
+    Engine::CGameObject::Compute_ViewZ(&vPos);
+}
+
+void CCone::Render_GameObject()
+{
+    m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+    m_pTextureCom->Set_Texture(0);
+
+    if (FAILED(Engine::CGameObject::Set_Material()))
+        return;
+
+    m_pBufferCom->Render_Buffer();
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+}
+
+void CCone::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+{
+    if (m_pTransformCom)
+    {
+        MSG_BOX("Cone Scale Set Failed");
+        return;
+    }
+
+    _vec3 vScale = { fX, fY, fZ };
+    m_pTransformCom->Set_Scale(vScale);
+}
+
+HRESULT CCone::Add_Component()
+{
+    CComponent* pComponent = nullptr;
+
+    pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+    pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Cone"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
+
+    return S_OK;
+}
+
+void CCone::BillBoard()
+{
+    _matrix		matWorld, matView, matBill;
+
+    m_pTransformCom->Get_World(&matWorld);
+    CGameObject* pCamera = CManagement::GetInstance()->Get_GameObject(L"Environment_Layer", L"DynamicCamera");
+    matView = *dynamic_cast<CCamera*>(pCamera)->Get_View();
+    D3DXMatrixIdentity(&matBill);
+
+    matBill._11 = matView._11;
+    matBill._12 = matView._12;
+    matBill._13 = matView._13;
+    matBill._21 = matView._21;
+    matBill._22 = matView._22;
+    matBill._23 = matView._23;
+    matBill._31 = matView._31;
+    matBill._32 = matView._32;
+    matBill._33 = matView._33;
+
+    D3DXMatrixInverse(&matBill, 0, &matBill);
+
+    matWorld = matBill * matWorld;
+
+    m_pTransformCom->Set_World(&matWorld);
+}
+
+CCone* CCone::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+{
+    CCone* pCone = new CCone(pGraphicDev);
+
+    if (FAILED(pCone->Ready_GameObject()))
+    {
+        Safe_Release(pCone);
+        MSG_BOX("Cone Create Failed");
+        return nullptr;
+    }
+
+    return pCone;
+}
+
+void CCone::Free()
+{
+    Engine::CGameObject::Free();
+}

--- a/Client/Code/CHydrant.cpp
+++ b/Client/Code/CHydrant.cpp
@@ -89,7 +89,7 @@ HRESULT CHydrant::Add_Component()
         return E_FAIL;
     m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
 
-    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Hydrant"));
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_DecoTexture_Hydrant"));
     if (nullptr == pComponent)
         return E_FAIL;
     m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });

--- a/Client/Code/CHydrant.cpp
+++ b/Client/Code/CHydrant.cpp
@@ -1,0 +1,143 @@
+#include "pch.h"
+#include "CHydrant.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "CManagement.h"
+#include "CCamera.h"
+
+CHydrant::CHydrant(LPDIRECT3DDEVICE9 pGraphicDev)
+    : Engine::CGameObject(pGraphicDev)
+{
+}
+
+CHydrant::CHydrant(const CGameObject& rhs)
+    : Engine::CGameObject(rhs)
+{
+}
+
+CHydrant::~CHydrant()
+{
+}
+
+HRESULT CHydrant::Ready_GameObject()
+{
+    if (FAILED(Add_Component()))
+        return E_FAIL;
+
+    return S_OK;
+}
+
+_int CHydrant::Update_GameObject(const _float& fTimeDelta)
+{
+    _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+    BillBoard();
+
+    CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+    return iExit;
+}
+
+void CHydrant::LateUpdate_GameObject(const _float& fTimeDelta)
+{
+    Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
+
+    _vec3 vPos;
+    m_pTransformCom->Get_Info(INFO_POS, &vPos);
+    Engine::CGameObject::Compute_ViewZ(&vPos);
+}
+
+void CHydrant::Render_GameObject()
+{
+    m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+    m_pTextureCom->Set_Texture(0);
+
+    if (FAILED(Engine::CGameObject::Set_Material()))
+        return;
+
+    m_pBufferCom->Render_Buffer();
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+}
+
+void CHydrant::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+{
+    if (m_pTransformCom)
+    {
+        MSG_BOX("Hydrant Scale Set Failed");
+        return;
+    }
+
+    _vec3 vScale = { fX, fY, fZ };
+    m_pTransformCom->Set_Scale(vScale);
+}
+
+HRESULT CHydrant::Add_Component()
+{
+    CComponent* pComponent = nullptr;
+
+    pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+    pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Hydrant"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
+
+    return S_OK;
+}
+
+void CHydrant::BillBoard()
+{
+    _matrix		matWorld, matView, matBill;
+
+    m_pTransformCom->Get_World(&matWorld);
+    CGameObject* pCamera = CManagement::GetInstance()->Get_GameObject(L"Environment_Layer", L"DynamicCamera");
+    matView = *dynamic_cast<CCamera*>(pCamera)->Get_View();
+    D3DXMatrixIdentity(&matBill);
+
+    matBill._11 = matView._11;  
+    matBill._12 = matView._12;
+    matBill._13 = matView._13;
+    matBill._21 = matView._21;
+    matBill._22 = matView._22;
+    matBill._23 = matView._23;
+    matBill._31 = matView._31;
+    matBill._32 = matView._32;
+    matBill._33 = matView._33;
+
+    D3DXMatrixInverse(&matBill, 0, &matBill);
+
+    matWorld = matBill * matWorld;
+
+    m_pTransformCom->Set_World(&matWorld);
+}
+
+CHydrant* CHydrant::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+{
+    CHydrant* pHydrant = new CHydrant(pGraphicDev);
+
+    if (FAILED(pHydrant->Ready_GameObject()))
+    {
+        Safe_Release(pHydrant);
+        MSG_BOX("Hydrant Create Failed");
+        return nullptr;
+    }
+
+    return pHydrant;
+}
+
+void CHydrant::Free()
+{
+    Engine::CGameObject::Free();
+}

--- a/Client/Code/CLoading.cpp
+++ b/Client/Code/CLoading.cpp
@@ -512,39 +512,43 @@ _uint CLoading::Loading_ForStage()
 
 	////// Environment Stage Object //////
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
-	(L"Proto_Deco_CherryTree", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_cherrytree%d.png", TEX_NORMAL, 12))))
+	(L"Proto_DecoTexture_CherryTree", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Deco/deco_cherrytree%d.png", TEX_NORMAL, 12))))
 		return E_FAIL;
 
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
-	(L"Proto_Deco_Car", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_car%d.png", TEX_NORMAL, 4))))
+	(L"Proto_DecoTexture_Car", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Deco/deco_car%d.png", TEX_NORMAL, 4))))
 		return E_FAIL;
 
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
-	(L"Proto_Deco_Bamboo", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_bamboo%d.png", TEX_NORMAL, 4))))
+	(L"Proto_DecoTexture_Bamboo", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Deco/deco_bamboo%d.png", TEX_NORMAL, 4))))
 		return E_FAIL;
 
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
-	(L"Proto_Deco_Torch", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_torch.png", TEX_NORMAL))))
+	(L"Proto_DecoTexture_Torch", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Deco/deco_torch.png", TEX_NORMAL))))
 		return E_FAIL;
 
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
-	(L"Proto_Deco_TrafficLight", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_trafficlight%d.png", TEX_NORMAL, 3))))
+	(L"Proto_DecoTexture_TrafficLight", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Deco/deco_trafficlight%d.png", TEX_NORMAL, 3))))
 		return E_FAIL;
 
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
-	(L"Proto_Deco_Hydrant", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_hydrant.png", TEX_NORMAL))))
+	(L"Proto_DecoTexture_Hydrant", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Deco/deco_hydrant.png", TEX_NORMAL))))
 		return E_FAIL;
 
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
-	(L"Proto_Deco_Cone", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_cone.png", TEX_NORMAL))))
+	(L"Proto_DecoTexture_Cone", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Deco/deco_cone.png", TEX_NORMAL))))
 		return E_FAIL;
 
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
-	(L"Proto_Deco_Pigeon", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_pigeon%d.png", TEX_NORMAL, 4))))
+	(L"Proto_DecoTexture_Pigeon", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Deco/deco_pigeon%d.png", TEX_NORMAL, 4))))
 		return E_FAIL;
 
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
-	(L"Proto_Deco_Sandbag", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_sandbag%d.png", TEX_NORMAL, 6))))
+	(L"Proto_DecoTexture_Sandbag", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Deco/deco_sandbag%d.png", TEX_NORMAL, 6))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_DecoTexture_Table", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Deco/deco_table%d.dds", TEX_CUBE, 4))))
 		return E_FAIL;
 
   	////// Effect //////

--- a/Client/Code/CLoading.cpp
+++ b/Client/Code/CLoading.cpp
@@ -503,6 +503,41 @@ _uint CLoading::Loading_ForStage()
 		return E_FAIL;
 
 	////// Environment Stage Object //////
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_Deco_CherryTree", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_cherrytree%d.png", TEX_NORMAL, 12))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_Deco_Car", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_car%d.png", TEX_NORMAL, 4))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_Deco_Bamboo", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_bamboo%d.png", TEX_NORMAL, 4))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_Deco_Torch", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_torch.png", TEX_NORMAL))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_Deco_TrafficLight", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_trafficlight%d.png", TEX_NORMAL, 3))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_Deco_Hydrant", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_hydrant.png", TEX_NORMAL))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_Deco_Cone", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_cone.png", TEX_NORMAL))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_Deco_Pigeon", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_pigeon%d.png", TEX_NORMAL, 4))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_Deco_Sandbag", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_sandbag%d.png", TEX_NORMAL, 6))))
+		return E_FAIL;
 
   	////// Effect //////
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype

--- a/Client/Code/CLoading.cpp
+++ b/Client/Code/CLoading.cpp
@@ -502,6 +502,14 @@ _uint CLoading::Loading_ForStage()
 	(L"Proto_EnvironmentTexture_Wall_Wood", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Wall/wall_wood.dds", TEX_CUBE))))
 		return E_FAIL;
 
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_EnvironmentTexture_Wall_Basket", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Wall/wall_barrier.dds", TEX_CUBE))))
+		return E_FAIL;
+
+	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
+	(L"Proto_EnvironmentTexture_Wall_Barrier", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Environment/Stage/Wall/wall_basket.dds", TEX_CUBE))))
+		return E_FAIL;
+
 	////// Environment Stage Object //////
 	if (FAILED(CProtoMgr::GetInstance()->Ready_Prototype
 	(L"Proto_Deco_CherryTree", CTexture::Create(m_pGraphicDev, L"../Bin/Resource/Texture/Object/deco/deco_cherrytree%d.png", TEX_NORMAL, 12))))

--- a/Client/Code/CPigeon.cpp
+++ b/Client/Code/CPigeon.cpp
@@ -91,7 +91,7 @@ HRESULT CPigeon::Add_Component()
         return E_FAIL;
     m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
 
-    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Pigeon"));
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_DecoTexture_Pigeon"));
     if (nullptr == pComponent)
         return E_FAIL;
     m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });

--- a/Client/Code/CPigeon.cpp
+++ b/Client/Code/CPigeon.cpp
@@ -1,0 +1,145 @@
+#include "pch.h"
+#include "CPigeon.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "CManagement.h"
+#include "CCamera.h"
+
+CPigeon::CPigeon(LPDIRECT3DDEVICE9 pGraphicDev)
+    : Engine::CGameObject(pGraphicDev)
+{
+}
+
+CPigeon::CPigeon(const CGameObject& rhs)
+    : Engine::CGameObject(rhs)
+{
+}
+
+CPigeon::~CPigeon()
+{
+}
+
+HRESULT CPigeon::Ready_GameObject()
+{
+    if (FAILED(Add_Component()))
+        return E_FAIL;
+
+    m_iFrame = rand() % 4;
+
+    return S_OK;
+}
+
+_int CPigeon::Update_GameObject(const _float& fTimeDelta)
+{
+    _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+    BillBoard();
+
+    CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+    return iExit;
+}
+
+void CPigeon::LateUpdate_GameObject(const _float& fTimeDelta)
+{
+    Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
+
+    _vec3 vPos;
+    m_pTransformCom->Get_Info(INFO_POS, &vPos);
+    Engine::CGameObject::Compute_ViewZ(&vPos);
+}
+
+void CPigeon::Render_GameObject()
+{
+    m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+    m_pTextureCom->Set_Texture(m_iFrame);
+
+    if (FAILED(Engine::CGameObject::Set_Material()))
+        return;
+
+    m_pBufferCom->Render_Buffer();
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+}
+
+void CPigeon::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+{
+    if (m_pTransformCom)
+    {
+        MSG_BOX("Pigeon Scale Set Failed");
+        return;
+    }
+
+    _vec3 vScale = { fX, fY, fZ };
+    m_pTransformCom->Set_Scale(vScale);
+}
+
+HRESULT CPigeon::Add_Component()
+{
+    CComponent* pComponent = nullptr;
+
+    pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+    pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Pigeon"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
+
+    return S_OK;
+}
+
+void CPigeon::BillBoard()
+{
+    _matrix		matWorld, matView, matBill;
+
+    m_pTransformCom->Get_World(&matWorld);
+    CGameObject* pCamera = CManagement::GetInstance()->Get_GameObject(L"Environment_Layer", L"DynamicCamera");
+    matView = *dynamic_cast<CCamera*>(pCamera)->Get_View();
+    D3DXMatrixIdentity(&matBill);
+
+    matBill._11 = matView._11;
+    matBill._12 = matView._12;
+    matBill._13 = matView._13;
+    matBill._21 = matView._21;
+    matBill._22 = matView._22;
+    matBill._23 = matView._23;
+    matBill._31 = matView._31;
+    matBill._32 = matView._32;
+    matBill._33 = matView._33;
+
+    D3DXMatrixInverse(&matBill, 0, &matBill);
+
+    matWorld = matBill * matWorld;
+
+    m_pTransformCom->Set_World(&matWorld);
+}
+
+CPigeon* CPigeon::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+{
+    CPigeon* pPigeon = new CPigeon(pGraphicDev);
+
+    if (FAILED(pPigeon->Ready_GameObject()))
+    {
+        Safe_Release(pPigeon);
+        MSG_BOX("Pigeon Create Failed");
+        return nullptr;
+    }
+
+    return pPigeon;
+}
+
+void CPigeon::Free()
+{
+    Engine::CGameObject::Free();
+}

--- a/Client/Code/CSandbag.cpp
+++ b/Client/Code/CSandbag.cpp
@@ -1,0 +1,145 @@
+#include "pch.h"
+#include "CSandbag.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "CManagement.h"
+#include "CCamera.h"
+
+CSandbag::CSandbag(LPDIRECT3DDEVICE9 pGraphicDev)
+    : Engine::CGameObject(pGraphicDev)
+{
+}
+
+CSandbag::CSandbag(const CGameObject& rhs)
+    : Engine::CGameObject(rhs)
+{
+}
+
+CSandbag::~CSandbag()
+{
+}
+
+HRESULT CSandbag::Ready_GameObject()
+{
+    if (FAILED(Add_Component()))
+        return E_FAIL;
+
+    m_iFrame = rand() % 4;
+
+    return S_OK;
+}
+
+_int CSandbag::Update_GameObject(const _float& fTimeDelta)
+{
+    _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+    BillBoard();
+
+    CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+    return iExit;
+}
+
+void CSandbag::LateUpdate_GameObject(const _float& fTimeDelta)
+{
+    Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
+
+    _vec3 vPos;
+    m_pTransformCom->Get_Info(INFO_POS, &vPos);
+    Engine::CGameObject::Compute_ViewZ(&vPos);
+}
+
+void CSandbag::Render_GameObject()
+{
+    m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+    m_pTextureCom->Set_Texture(m_iFrame);
+
+    if (FAILED(Engine::CGameObject::Set_Material()))
+        return;
+
+    m_pBufferCom->Render_Buffer();
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+}
+
+void CSandbag::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+{
+    if (m_pTransformCom)
+    {
+        MSG_BOX("Sandbag Scale Set Failed");
+        return;
+    }
+
+    _vec3 vScale = { fX, fY, fZ };
+    m_pTransformCom->Set_Scale(vScale);
+}
+
+HRESULT CSandbag::Add_Component()
+{
+    CComponent* pComponent = nullptr;
+
+    pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+    pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Sandbag"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
+
+    return S_OK;
+}
+
+void CSandbag::BillBoard()
+{
+    _matrix		matWorld, matView, matBill;
+
+    m_pTransformCom->Get_World(&matWorld);
+    CGameObject* pCamera = CManagement::GetInstance()->Get_GameObject(L"Environment_Layer", L"DynamicCamera");
+    matView = *dynamic_cast<CCamera*>(pCamera)->Get_View();
+    D3DXMatrixIdentity(&matBill);
+
+    matBill._11 = matView._11;
+    matBill._12 = matView._12;
+    matBill._13 = matView._13;
+    matBill._21 = matView._21;
+    matBill._22 = matView._22;
+    matBill._23 = matView._23;
+    matBill._31 = matView._31;
+    matBill._32 = matView._32;
+    matBill._33 = matView._33;
+
+    D3DXMatrixInverse(&matBill, 0, &matBill);
+
+    matWorld = matBill * matWorld;
+
+    m_pTransformCom->Set_World(&matWorld);
+}
+
+CSandbag* CSandbag::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+{
+    CSandbag* pSandbag = new CSandbag(pGraphicDev);
+
+    if (FAILED(pSandbag->Ready_GameObject()))
+    {
+        Safe_Release(pSandbag);
+        MSG_BOX("Sandbag Create Failed");
+        return nullptr;
+    }
+
+    return pSandbag;
+}
+
+void CSandbag::Free()
+{
+    Engine::CGameObject::Free();
+}

--- a/Client/Code/CSandbag.cpp
+++ b/Client/Code/CSandbag.cpp
@@ -91,7 +91,7 @@ HRESULT CSandbag::Add_Component()
         return E_FAIL;
     m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
 
-    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Sandbag"));
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_DecoTexture_Sandbag"));
     if (nullptr == pComponent)
         return E_FAIL;
     m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });

--- a/Client/Code/CTable.cpp
+++ b/Client/Code/CTable.cpp
@@ -1,0 +1,129 @@
+#include "pch.h"
+#include "CTable.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+
+CTable::CTable(LPDIRECT3DDEVICE9 pGraphicDev)
+    : CGameObject(pGraphicDev), m_iFrame(0)
+{
+}
+
+CTable::CTable(const CGameObject& rhs)
+    : CGameObject(rhs), m_iFrame(0)
+{
+}
+
+CTable::~CTable()
+{
+}
+
+HRESULT CTable::Ready_GameObject()
+{
+    if (FAILED(Add_Component()))
+        return E_FAIL;
+
+    return S_OK;
+}
+
+_int CTable::Update_GameObject(const _float& fTimeDelta)
+{
+    _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+    CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+    return iExit;
+}
+
+void CTable::LateUpdate_GameObject(const _float& fTimeDelta)
+{
+    Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
+
+    return;
+}
+
+void CTable::Render_GameObject()
+{
+    m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+    m_pGraphicDev->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
+    if (FAILED(Set_Material()))
+        return;
+
+    m_pTextureCom->Set_Texture(m_iFrame);
+
+    m_pBufferCom->Render_Buffer();
+
+    m_pGraphicDev->SetRenderState(D3DRS_CULLMODE, D3DCULL_CCW);
+}
+
+void CTable::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+{
+    if (m_pTransformCom)
+    {
+        MSG_BOX("Table Scale Set Failed");
+        return;
+    }
+
+    _vec3 vScale = { fX, fY, fZ };
+    m_pTransformCom->Set_Scale(vScale);
+}
+
+void CTable::Set_Texture(TABLETYPE eDir)
+{
+    switch (eDir)
+    {
+    case BLACK:
+        m_iFrame = 0;
+        break;
+    case WHITE:
+        m_iFrame = 1;
+        break;
+    case GREEN:
+        m_iFrame = 2;
+        break;
+    case CHECK:
+        m_iFrame = 3;
+        break;
+    }
+}
+
+HRESULT CTable::Add_Component()
+{
+    CComponent* pComponent = nullptr;
+
+    pComponent = m_pBufferCom = dynamic_cast<Engine::CCubeTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_CubeTex"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+    pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_DecoTexture_Table"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
+
+    return S_OK;
+}
+
+CTable* CTable::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+{
+    CTable* pTable = new CTable(pGraphicDev);
+
+    if (FAILED(pTable->Ready_GameObject()))
+    {
+        Safe_Release(pTable);
+        MSG_BOX("Table Create Failed");
+        return nullptr;
+    }
+
+    return pTable;
+}
+
+void CTable::Free()
+{
+    Engine::CGameObject::Free();
+}

--- a/Client/Code/CTorch.cpp
+++ b/Client/Code/CTorch.cpp
@@ -1,0 +1,143 @@
+#include "pch.h"
+#include "CTorch.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "CManagement.h"
+#include "CCamera.h"
+
+CTorch::CTorch(LPDIRECT3DDEVICE9 pGraphicDev)
+    : Engine::CGameObject(pGraphicDev)
+{
+}
+
+CTorch::CTorch(const CGameObject& rhs)
+    : Engine::CGameObject(rhs)
+{
+}
+
+CTorch::~CTorch()
+{
+}
+
+HRESULT CTorch::Ready_GameObject()
+{
+    if (FAILED(Add_Component()))
+        return E_FAIL;
+
+    return S_OK;
+}
+
+_int CTorch::Update_GameObject(const _float& fTimeDelta)
+{
+    _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+    BillBoard();
+
+    CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+    return iExit;
+}
+
+void CTorch::LateUpdate_GameObject(const _float& fTimeDelta)
+{
+    Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
+
+    _vec3 vPos;
+    m_pTransformCom->Get_Info(INFO_POS, &vPos);
+    Engine::CGameObject::Compute_ViewZ(&vPos);
+}
+
+void CTorch::Render_GameObject()
+{
+    m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+    m_pTextureCom->Set_Texture(0);
+
+    if (FAILED(Engine::CGameObject::Set_Material()))
+        return;
+
+    m_pBufferCom->Render_Buffer();
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+}
+
+void CTorch::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+{
+    if (m_pTransformCom)
+    {
+        MSG_BOX("Torch Scale Set Failed");
+        return;
+    }
+
+    _vec3 vScale = { fX, fY, fZ };
+    m_pTransformCom->Set_Scale(vScale);
+}
+
+HRESULT CTorch::Add_Component()
+{
+    CComponent* pComponent = nullptr;
+
+    pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+    pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Torch"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
+
+    return S_OK;
+}
+
+void CTorch::BillBoard()
+{
+    _matrix		matWorld, matView, matBill;
+
+    m_pTransformCom->Get_World(&matWorld);
+    CGameObject* pCamera = CManagement::GetInstance()->Get_GameObject(L"Environment_Layer", L"DynamicCamera");
+    matView = *dynamic_cast<CCamera*>(pCamera)->Get_View();
+    D3DXMatrixIdentity(&matBill);
+
+    matBill._11 = matView._11;
+    matBill._12 = matView._12;
+    matBill._13 = matView._13;
+    matBill._21 = matView._21;
+    matBill._22 = matView._22;
+    matBill._23 = matView._23;
+    matBill._31 = matView._31;
+    matBill._32 = matView._32;
+    matBill._33 = matView._33;
+
+    D3DXMatrixInverse(&matBill, 0, &matBill);
+
+    matWorld = matBill * matWorld;
+
+    m_pTransformCom->Set_World(&matWorld);
+}
+
+CTorch* CTorch::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+{
+    CTorch* pTorch = new CTorch(pGraphicDev);
+
+    if (FAILED(pTorch->Ready_GameObject()))
+    {
+        Safe_Release(pTorch);
+        MSG_BOX("Torch Create Failed");
+        return nullptr;
+    }
+
+    return pTorch;
+}
+
+void CTorch::Free()
+{
+    Engine::CGameObject::Free();
+}

--- a/Client/Code/CTorch.cpp
+++ b/Client/Code/CTorch.cpp
@@ -89,7 +89,7 @@ HRESULT CTorch::Add_Component()
         return E_FAIL;
     m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
 
-    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_Torch"));
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_DecoTexture_Torch"));
     if (nullptr == pComponent)
         return E_FAIL;
     m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });

--- a/Client/Code/CTrafficLight.cpp
+++ b/Client/Code/CTrafficLight.cpp
@@ -105,7 +105,7 @@ HRESULT CTrafficLight::Add_Component()
         return E_FAIL;
     m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
 
-    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_TrafficLight"));
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_DecoTexture_TrafficLight"));
     if (nullptr == pComponent)
         return E_FAIL;
     m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });

--- a/Client/Code/CTrafficLight.cpp
+++ b/Client/Code/CTrafficLight.cpp
@@ -1,0 +1,159 @@
+#include "pch.h"
+#include "CTrafficLight.h"
+#include "CProtoMgr.h"
+#include "CRenderer.h"
+#include "CManagement.h"
+#include "CCamera.h"
+
+CTrafficLight::CTrafficLight(LPDIRECT3DDEVICE9 pGraphicDev)
+    : Engine::CGameObject(pGraphicDev), m_iFrame(0)
+{
+}
+
+CTrafficLight::CTrafficLight(const CGameObject& rhs)
+    : Engine::CGameObject(rhs), m_iFrame(0)
+{
+}
+
+CTrafficLight::~CTrafficLight()
+{
+}
+
+HRESULT CTrafficLight::Ready_GameObject()
+{
+    if (FAILED(Add_Component()))
+        return E_FAIL;
+
+    return S_OK;
+}
+
+_int CTrafficLight::Update_GameObject(const _float& fTimeDelta)
+{
+    _uint iExit = Engine::CGameObject::Update_GameObject(fTimeDelta);
+
+    BillBoard();
+
+    CRenderer::GetInstance()->Add_RenderGroup(RENDER_ALPHA, this);
+
+    return iExit;
+}
+
+void CTrafficLight::LateUpdate_GameObject(const _float& fTimeDelta)
+{
+    Engine::CGameObject::LateUpdate_GameObject(fTimeDelta);
+
+    _vec3 vPos;
+    m_pTransformCom->Get_Info(INFO_POS, &vPos);
+    Engine::CGameObject::Compute_ViewZ(&vPos);
+}
+
+void CTrafficLight::Render_GameObject()
+{
+    m_pGraphicDev->SetTransform(D3DTS_WORLD, m_pTransformCom->Get_World());
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, FALSE);
+
+    m_pTextureCom->Set_Texture(m_iFrame);
+
+    if (FAILED(Engine::CGameObject::Set_Material()))
+        return;
+
+    m_pBufferCom->Render_Buffer();
+
+    m_pGraphicDev->SetRenderState(D3DRS_ZWRITEENABLE, TRUE);
+}
+
+void CTrafficLight::Set_Scale(const _float& fX, const _float& fY, const _float& fZ)
+{
+    if (m_pTransformCom)
+    {
+        MSG_BOX("TrafficLight Scale Set Failed");
+        return;
+    }
+
+    _vec3 vScale = { fX, fY, fZ };
+    m_pTransformCom->Set_Scale(vScale);
+}
+
+void CTrafficLight::Set_Texture(TLPOSDIR eDir)
+{
+    switch (eDir)
+    {
+    case L_FWD: 
+        m_iFrame = 0;
+        break;
+    case R_FWD:
+        m_iFrame = 1;
+        break;
+    case R_LEFT:
+        m_iFrame = 2;
+        break;
+    }
+}
+
+HRESULT CTrafficLight::Add_Component()
+{
+    CComponent* pComponent = nullptr;
+
+    pComponent = m_pBufferCom = dynamic_cast<Engine::CRcTex*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_RcTex"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Buffer", pComponent });
+
+    pComponent = m_pTransformCom = dynamic_cast<Engine::CTransform*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Transform"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_DYNAMIC].insert({ L"Com_Transform", pComponent });
+
+    pComponent = m_pTextureCom = dynamic_cast<Engine::CTexture*>(CProtoMgr::GetInstance()->Clone_Prototype(L"Proto_Deco_TrafficLight"));
+    if (nullptr == pComponent)
+        return E_FAIL;
+    m_mapComponent[ID_STATIC].insert({ L"Com_Texture", pComponent });
+
+    return S_OK;
+}
+
+void CTrafficLight::BillBoard()
+{
+    _matrix		matWorld, matView, matBill;
+
+    m_pTransformCom->Get_World(&matWorld);
+    CGameObject* pCamera = CManagement::GetInstance()->Get_GameObject(L"Environment_Layer", L"DynamicCamera");
+    matView = *dynamic_cast<CCamera*>(pCamera)->Get_View();
+    D3DXMatrixIdentity(&matBill);
+
+    matBill._11 = matView._11;
+    matBill._12 = matView._12;
+    matBill._13 = matView._13;
+    matBill._21 = matView._21;
+    matBill._22 = matView._22;
+    matBill._23 = matView._23;
+    matBill._31 = matView._31;
+    matBill._32 = matView._32;
+    matBill._33 = matView._33;
+
+    D3DXMatrixInverse(&matBill, 0, &matBill);
+
+    matWorld = matBill * matWorld;
+
+    m_pTransformCom->Set_World(&matWorld);
+}
+
+CTrafficLight* CTrafficLight::Create(LPDIRECT3DDEVICE9 pGraphicDev)
+{
+    CTrafficLight* pTrafficLight = new CTrafficLight(pGraphicDev);
+
+    if (FAILED(pTrafficLight->Ready_GameObject()))
+    {
+        Safe_Release(pTrafficLight);
+        MSG_BOX("TrafficLight Create Failed");
+        return nullptr;
+    }
+
+    return pTrafficLight;
+}
+
+void CTrafficLight::Free()
+{
+    Engine::CGameObject::Free();
+}

--- a/Client/Header/CBamboo.h
+++ b/Client/Header/CBamboo.h
@@ -1,0 +1,52 @@
+/**
+* @file		CBamboo.h
+* @date		2025-07-19
+* @author	권예지
+* @brief	인게임 데코 오브젝트 클래스
+* @details	Stage 1, 3, 4
+*			스케일 : 1.5
+*			랜덤 텍스쳐 (0 ~ 3)
+*			(배치할 때 참고) 되도록이면 x 축으로 화면 가운데에 둘 것 (왼쪽이나 오른쪽으로 치우치면 원근감이 이상해짐)
+*/
+#pragma once
+#include "CGameObject.h"
+
+namespace Engine
+{
+	class CRcTex;
+	class CTransform;
+	class CTexture;
+}
+
+class CBamboo : public Engine::CGameObject
+{
+private:
+	explicit CBamboo(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CBamboo(const CGameObject& rhs);
+	virtual ~CBamboo();
+
+public:
+	virtual		HRESULT		Ready_GameObject();
+	virtual		_int		Update_GameObject(const _float& fTimeDelta);
+	virtual		void		LateUpdate_GameObject(const _float& fTimeDelta);
+	virtual		void		Render_GameObject();
+
+	void		Set_Scale(const _float& fX, const _float& fY, const _float& fZ);
+
+private:
+	HRESULT		Add_Component();
+	void		BillBoard();
+
+private:
+	Engine::CRcTex* m_pBufferCom;
+	Engine::CTransform* m_pTransformCom;
+	Engine::CTexture* m_pTextureCom;
+
+	_int		m_iFrame;
+
+public:
+	static	CBamboo* Create(LPDIRECT3DDEVICE9 pGraphicDev);
+
+private:
+	virtual		void		Free();
+};

--- a/Client/Header/CBarrier.h
+++ b/Client/Header/CBarrier.h
@@ -1,9 +1,9 @@
 /**
-* @file		CBrickWall.h
-* @date		2025-07-18
+* @file		CBarrier.h
+* @date		2025-07-19
 * @author	권예지
 * @brief	인게임 벽 오브젝트 클래스
-* @details	Stage 1, 3
+* @details	Stage 4
 *			스케일 : x = 3  y = 2  z = 0.5 또는 1
 */
 #pragma once
@@ -16,12 +16,12 @@ namespace Engine
 	class CTexture;
 }
 
-class CBrickWall : public CGameObject
+class CBarrier : public CGameObject
 {
 protected:
-	explicit CBrickWall(LPDIRECT3DDEVICE9 pGraphicDev);
-	explicit CBrickWall(const CGameObject& rhs);
-	virtual ~CBrickWall();
+	explicit CBarrier(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CBarrier(const CGameObject& rhs);
+	virtual ~CBarrier();
 
 public:
 	virtual		HRESULT		Ready_GameObject();
@@ -40,7 +40,7 @@ private:
 	Engine::CTexture* m_pTextureCom;
 
 public:
-	static	CBrickWall*		Create(LPDIRECT3DDEVICE9 pGraphicDev);
+	static		CBarrier*	Create(LPDIRECT3DDEVICE9 pGraphicDev);
 
 private:
 	virtual		void		Free();

--- a/Client/Header/CBasket.h
+++ b/Client/Header/CBasket.h
@@ -1,10 +1,10 @@
 /**
-* @file		CBrickWall.h
-* @date		2025-07-18
+* @file		CBasket.h
+* @date		2025-07-19
 * @author	권예지
 * @brief	인게임 벽 오브젝트 클래스
-* @details	Stage 1, 3
-*			스케일 : x = 3  y = 2  z = 0.5 또는 1
+* @details	Stage 4
+*			스케일 : x = 3  y = 1  z = 0.5 또는 1
 */
 #pragma once
 #include "CGameObject.h"
@@ -16,12 +16,12 @@ namespace Engine
 	class CTexture;
 }
 
-class CBrickWall : public CGameObject
+class CBasket : public CGameObject
 {
 protected:
-	explicit CBrickWall(LPDIRECT3DDEVICE9 pGraphicDev);
-	explicit CBrickWall(const CGameObject& rhs);
-	virtual ~CBrickWall();
+	explicit CBasket(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CBasket(const CGameObject& rhs);
+	virtual ~CBasket();
 
 public:
 	virtual		HRESULT		Ready_GameObject();
@@ -40,7 +40,7 @@ private:
 	Engine::CTexture* m_pTextureCom;
 
 public:
-	static	CBrickWall*		Create(LPDIRECT3DDEVICE9 pGraphicDev);
+	static		CBasket*	Create(LPDIRECT3DDEVICE9 pGraphicDev);
 
 private:
 	virtual		void		Free();

--- a/Client/Header/CCar.h
+++ b/Client/Header/CCar.h
@@ -1,0 +1,50 @@
+/**
+* @file		CCar.h
+* @date		2025-07-19
+* @author	권예지
+* @brief	인게임 데코 오브젝트 클래스
+* @details	Stage 1, 3
+*			스케일 : 4
+*			랜덤 텍스쳐 (0 ~ 3)
+*/
+#pragma once
+#include "CGameObject.h"
+
+namespace Engine
+{
+	class CRcTileTex;
+	class CTransform;
+	class CTexture;
+}
+
+class CCar : public Engine::CGameObject
+{
+private:
+	explicit CCar(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CCar(const CGameObject& rhs);
+	virtual ~CCar();
+
+public:
+	virtual		HRESULT		Ready_GameObject();
+	virtual		_int		Update_GameObject(const _float& fTimeDelta);
+	virtual		void		LateUpdate_GameObject(const _float& fTimeDelta);
+	virtual		void		Render_GameObject();
+
+	void		Set_Scale(const _float& fX, const _float& fY, const _float& fZ);
+
+private:
+	HRESULT		Add_Component();
+
+private:
+	Engine::CRcTileTex* m_pBufferCom;
+	Engine::CTransform* m_pTransformCom;
+	Engine::CTexture* m_pTextureCom;
+
+	_int			m_iFrame;
+
+public:
+	static		CCar*		Create(LPDIRECT3DDEVICE9 pGraphicDev);
+
+private:
+	virtual		void		Free();
+};

--- a/Client/Header/CCherryTree.h
+++ b/Client/Header/CCherryTree.h
@@ -1,0 +1,51 @@
+/**
+* @file		CCherryTree.h
+* @date		2025-07-19
+* @author	권예지
+* @brief	인게임 데코 오브젝트 클래스
+* @details	Stage 1, 2, 3, 4
+*			스케일 : 4
+*			랜덤 텍스쳐 (0 ~ 11)
+*/
+#pragma once
+#include "CGameObject.h"
+
+namespace Engine
+{
+	class CRcTex;
+	class CTransform;
+	class CTexture;
+}
+
+class CCherryTree : public Engine::CGameObject
+{
+private:
+	explicit CCherryTree(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CCherryTree(const CGameObject& rhs);
+	virtual ~CCherryTree();
+
+public:
+	virtual		HRESULT		Ready_GameObject();
+	virtual		_int		Update_GameObject(const _float& fTimeDelta);
+	virtual		void		LateUpdate_GameObject(const _float& fTimeDelta);
+	virtual		void		Render_GameObject();
+
+	void		Set_Scale(const _float& fX, const _float& fY, const _float& fZ);
+
+private:
+	HRESULT		Add_Component();
+	void		BillBoard();
+
+private:
+	Engine::CRcTex* m_pBufferCom;
+	Engine::CTransform* m_pTransformCom;
+	Engine::CTexture* m_pTextureCom;
+
+	_int		m_iFrame;
+
+public:
+	static	CCherryTree*	Create(LPDIRECT3DDEVICE9 pGraphicDev);
+
+private:
+	virtual		void		Free();
+};

--- a/Client/Header/CCone.h
+++ b/Client/Header/CCone.h
@@ -1,0 +1,48 @@
+/**
+* @file		CCone.h
+* @date		2025-07-19
+* @author	권예지
+* @brief	인게임 데코 오브젝트 클래스
+* @details	Stage 1, 3
+*			스케일 : 1
+*/
+#pragma once
+#include "CGameObject.h"
+
+namespace Engine
+{
+	class CRcTex;
+	class CTransform;
+	class CTexture;
+}
+
+class CCone : public Engine::CGameObject
+{
+private:
+	explicit CCone(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CCone(const CGameObject& rhs);
+	virtual ~CCone();
+
+public:
+	virtual		HRESULT		Ready_GameObject();
+	virtual		_int		Update_GameObject(const _float& fTimeDelta);
+	virtual		void		LateUpdate_GameObject(const _float& fTimeDelta);
+	virtual		void		Render_GameObject();
+
+	void		Set_Scale(const _float& fX, const _float& fY, const _float& fZ);
+
+private:
+	HRESULT		Add_Component();
+	void		BillBoard();
+
+private:
+	Engine::CRcTex* m_pBufferCom;
+	Engine::CTransform* m_pTransformCom;
+	Engine::CTexture* m_pTextureCom;
+
+public:
+	static		CCone*		Create(LPDIRECT3DDEVICE9 pGraphicDev);
+
+private:
+	virtual		void		Free();
+};

--- a/Client/Header/CHydrant.h
+++ b/Client/Header/CHydrant.h
@@ -1,0 +1,48 @@
+/**
+* @file		CHydrant.h
+* @date		2025-07-19
+* @author	권예지
+* @brief	인게임 데코 오브젝트 클래스
+* @details	Stage 1, 3
+*			스케일 : 1
+*/
+#pragma once
+#include "CGameObject.h"
+
+namespace Engine
+{
+	class CRcTex;
+	class CTransform;
+	class CTexture;
+}
+
+class CHydrant : public Engine::CGameObject
+{
+private:
+	explicit CHydrant(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CHydrant(const CGameObject& rhs);
+	virtual ~CHydrant();
+
+public:
+	virtual		HRESULT		Ready_GameObject();
+	virtual		_int		Update_GameObject(const _float& fTimeDelta);
+	virtual		void		LateUpdate_GameObject(const _float& fTimeDelta);
+	virtual		void		Render_GameObject();
+
+	void		Set_Scale(const _float& fX, const _float& fY, const _float& fZ);
+
+private:
+	HRESULT		Add_Component();
+	void		BillBoard();
+
+private:
+	Engine::CRcTex* m_pBufferCom;
+	Engine::CTransform* m_pTransformCom;
+	Engine::CTexture* m_pTextureCom;
+
+public:
+	static		CHydrant*	Create(LPDIRECT3DDEVICE9 pGraphicDev);
+
+private:
+	virtual		void		Free();
+};

--- a/Client/Header/CPigeon.h
+++ b/Client/Header/CPigeon.h
@@ -1,0 +1,50 @@
+/**
+* @file		CPigeon.h
+* @date		2025-07-19
+* @author	권예지
+* @brief	인게임 데코 오브젝트 클래스
+* @details	Stage 1, 3
+*			스케일 : 1
+*/
+#pragma once
+#include "CGameObject.h"
+
+namespace Engine
+{
+	class CRcTex;
+	class CTransform;
+	class CTexture;
+}
+
+class CPigeon : public Engine::CGameObject
+{
+private:
+	explicit CPigeon(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CPigeon(const CGameObject& rhs);
+	virtual ~CPigeon();
+
+public:
+	virtual		HRESULT		Ready_GameObject();
+	virtual		_int		Update_GameObject(const _float& fTimeDelta);
+	virtual		void		LateUpdate_GameObject(const _float& fTimeDelta);
+	virtual		void		Render_GameObject();
+
+	void		Set_Scale(const _float& fX, const _float& fY, const _float& fZ);
+
+private:
+	HRESULT		Add_Component();
+	void		BillBoard();
+
+private:
+	Engine::CRcTex* m_pBufferCom;
+	Engine::CTransform* m_pTransformCom;
+	Engine::CTexture* m_pTextureCom;
+
+	_int		m_iFrame;
+
+public:
+	static		CPigeon*	Create(LPDIRECT3DDEVICE9 pGraphicDev);
+
+private:
+	virtual		void		Free();
+};

--- a/Client/Header/CSandbag.h
+++ b/Client/Header/CSandbag.h
@@ -1,0 +1,51 @@
+/**
+* @file		CSandbag.h
+* @date		2025-07-19
+* @author	권예지
+* @brief	인게임 데코 오브젝트 클래스
+* @details	Stage 5, 6
+*			스케일 : 1
+*			랜덤 텍스쳐 (0 ~ 3)
+*/
+#pragma once
+#include "CGameObject.h"
+
+namespace Engine
+{
+	class CRcTex;
+	class CTransform;
+	class CTexture;
+}
+
+class CSandbag : public Engine::CGameObject
+{
+private:
+	explicit CSandbag(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CSandbag(const CGameObject& rhs);
+	virtual ~CSandbag();
+
+public:
+	virtual		HRESULT		Ready_GameObject();
+	virtual		_int		Update_GameObject(const _float& fTimeDelta);
+	virtual		void		LateUpdate_GameObject(const _float& fTimeDelta);
+	virtual		void		Render_GameObject();
+
+	void		Set_Scale(const _float& fX, const _float& fY, const _float& fZ);
+
+private:
+	HRESULT		Add_Component();
+	void		BillBoard();
+
+private:
+	Engine::CRcTex* m_pBufferCom;
+	Engine::CTransform* m_pTransformCom;
+	Engine::CTexture* m_pTextureCom;
+
+	_int		m_iFrame;
+
+public:
+	static		CSandbag*	Create(LPDIRECT3DDEVICE9 pGraphicDev);
+
+private:
+	virtual		void		Free();
+};

--- a/Client/Header/CTable.h
+++ b/Client/Header/CTable.h
@@ -1,0 +1,69 @@
+/**
+* @file		CTable.h
+* @date		2025-07-20
+* @author	권예지
+* @brief	인게임 데코 오브젝트 클래스
+* @details	Stage 1, 3
+*			스케일 : x = 1 y = 0.5  z = 1
+*			Set_Texture() 함수 호출해서 테이블 디자인 정해줘야
+*/
+#pragma once
+#include "CGameObject.h"
+
+namespace Engine
+{
+	class CCubeTex;
+	class CTransform;
+	class CTexture;
+}
+
+class CTable : public CGameObject
+{
+public:
+	/**
+	 * @enum	TABLETYPE
+	 * @brief	테이블 디자인 종류
+	 */
+	enum TABLETYPE
+	{
+		BLACK,
+		WHITE,
+		GREEN,
+		CHECK
+	};
+
+protected:
+	explicit CTable(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CTable(const CGameObject& rhs);
+	virtual ~CTable();
+
+public:
+	virtual		HRESULT		Ready_GameObject();
+	virtual		_int		Update_GameObject(const _float& fTimeDelta);
+	virtual		void		LateUpdate_GameObject(const _float& fTimeDelta);
+	virtual		void		Render_GameObject();
+
+	void		Set_Scale(const _float& fX, const _float& fY, const _float& fZ);
+
+	/**
+	 * @brief	테이블 디자인에 맞는 텍스쳐로 설정
+	 * @param	TABLETYPE : BLACK, WHITE, GREEN, CHECK
+	 */
+	void		Set_Texture(TABLETYPE eType);
+
+private:
+	HRESULT		Add_Component();
+
+private:
+	Engine::CCubeTex* m_pBufferCom;
+	Engine::CTransform* m_pTransformCom;
+	Engine::CTexture* m_pTextureCom;
+
+	int			m_iFrame;
+
+public:
+	static		CTable*		Create(LPDIRECT3DDEVICE9 pGraphicDev);
+
+private:
+	virtual		void		Free();
+};

--- a/Client/Header/CTorch.h
+++ b/Client/Header/CTorch.h
@@ -1,0 +1,49 @@
+/**
+* @file		CTorch.h
+* @date		2025-07-19
+* @author	권예지
+* @brief	인게임 데코 오브젝트 클래스
+* @details	Stage 5, 6
+*			스케일 : 1.5
+*			(배치할 때 참고) 되도록이면 x 축으로 화면 가운데에 둘 것 (왼쪽이나 오른쪽으로 치우치면 원근감이 이상해짐)
+*/
+#pragma once
+#include "CGameObject.h"
+
+namespace Engine
+{
+	class CRcTex;
+	class CTransform;
+	class CTexture;
+}
+
+class CTorch : public Engine::CGameObject
+{
+private:
+	explicit CTorch(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CTorch(const CGameObject& rhs);
+	virtual ~CTorch();
+
+public:
+	virtual		HRESULT		Ready_GameObject();
+	virtual		_int		Update_GameObject(const _float& fTimeDelta);
+	virtual		void		LateUpdate_GameObject(const _float& fTimeDelta);
+	virtual		void		Render_GameObject();
+
+	void		Set_Scale(const _float& fX, const _float& fY, const _float& fZ);
+
+private:
+	HRESULT		Add_Component();
+	void		BillBoard();
+
+private:
+	Engine::CRcTex* m_pBufferCom;
+	Engine::CTransform* m_pTransformCom;
+	Engine::CTexture* m_pTextureCom;
+
+public:
+	static		CTorch*		Create(LPDIRECT3DDEVICE9 pGraphicDev);
+
+private:
+	virtual		void		Free();
+};

--- a/Client/Header/CTrafficLight.h
+++ b/Client/Header/CTrafficLight.h
@@ -1,0 +1,69 @@
+/**
+* @file		CTrafficLight.h
+* @date		2025-07-19
+* @author	권예지
+* @brief	인게임 데코 오브젝트 클래스
+* @details	Stage 4
+*			스케일 : 1.5 ~ 2
+*			Set_Texture() 함수 호출해서 설치 위치와 바라보는 방향에 맞는 텍스쳐 설정해줘야
+*/
+#pragma once
+#include "CGameObject.h"
+
+namespace Engine
+{
+	class CRcTex;
+	class CTransform;
+	class CTexture;
+}
+
+class CTrafficLight : public Engine::CGameObject
+{
+public:
+	/**
+	 * @enum	TRAFFICLIGHTDIR
+	 * @brief	신호등 배치 위치와 바라보는 방향
+	 */
+	enum TLPOSDIR 
+	{ 
+		L_FWD,		///< 왼쪽에 배치, 정면 바라봄
+		R_FWD,		///< 오른쪽에 배치, 정면 바라봄
+		R_LEFT		///< 오른쪽에 배치, 왼쪽 바라봄
+	};
+
+private:
+	explicit CTrafficLight(LPDIRECT3DDEVICE9 pGraphicDev);
+	explicit CTrafficLight(const CGameObject& rhs);
+	virtual ~CTrafficLight();
+
+public:
+	virtual		HRESULT		Ready_GameObject();
+	virtual		_int		Update_GameObject(const _float& fTimeDelta);
+	virtual		void		LateUpdate_GameObject(const _float& fTimeDelta);
+	virtual		void		Render_GameObject();
+
+	void		Set_Scale(const _float& fX, const _float& fY, const _float& fZ);
+
+	/**
+	 * @brief	신호등 배치 위치와 바라보는 방향에 따라 텍스쳐를 설정
+	 * @param	TRAFFICLIGHTDIR : LEFTFRONT(화면 왼쪽 배치, 정면 바라봄) / RIGHTFRONT(화면 오른쪽 배치, 정면 바라봄) / RIGHTSIDE(화면 오른쪽 배치, 왼쪽바라봄)
+	 */
+	void		Set_Texture(TLPOSDIR eDir);
+
+private:
+	HRESULT		Add_Component();
+	void		BillBoard();
+
+private:
+	Engine::CRcTex* m_pBufferCom;
+	Engine::CTransform* m_pTransformCom;
+	Engine::CTexture* m_pTextureCom;
+
+	int			m_iFrame;
+
+public:
+	static	CTrafficLight*	Create(LPDIRECT3DDEVICE9 pGraphicDev);
+
+private:
+	virtual		void		Free();
+};

--- a/Client/Header/CWoodWall.h
+++ b/Client/Header/CWoodWall.h
@@ -33,7 +33,6 @@ public:
 
 private:
 	HRESULT		Add_Component();
-	HRESULT		Set_Metarial();
 
 private:
 	Engine::CCubeTex* m_pBufferCom;

--- a/Client/Include/Client.vcxproj
+++ b/Client/Include/Client.vcxproj
@@ -212,6 +212,7 @@
     <ClInclude Include="..\Header\CStage.h" />
     <ClInclude Include="..\Header\CStoneBeigeTile.h" />
     <ClInclude Include="..\Header\CStoneBrownTile.h" />
+    <ClInclude Include="..\Header\CTable.h" />
     <ClInclude Include="..\Header\CTerrain.h" />
     <ClInclude Include="..\Header\CTestEffect.h" />
     <ClInclude Include="..\Header\CTomatoSoup.h" />
@@ -323,6 +324,7 @@
     <ClCompile Include="..\Code\CStage.cpp" />
     <ClCompile Include="..\Code\CStoneBeigeTile.cpp" />
     <ClCompile Include="..\Code\CStoneBrownTile.cpp" />
+    <ClCompile Include="..\Code\CTable.cpp" />
     <ClCompile Include="..\Code\CTerrain.cpp" />
     <ClCompile Include="..\Code\CTestEffect.cpp" />
     <ClCompile Include="..\Code\CTomatoSoup.cpp" />

--- a/Client/Include/Client.vcxproj
+++ b/Client/Include/Client.vcxproj
@@ -155,6 +155,8 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\Header\CBamboo.h" />
+    <ClInclude Include="..\Header\CBarrier.h" />
+    <ClInclude Include="..\Header\CBasket.h" />
     <ClInclude Include="..\Header\CBlue44Tile.h" />
     <ClInclude Include="..\Header\CBackGround.h" />
     <ClInclude Include="..\Header\CBlue33Tile.h" />
@@ -264,6 +266,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Code\CBamboo.cpp" />
+    <ClCompile Include="..\Code\CBarrier.cpp" />
+    <ClCompile Include="..\Code\CBasket.cpp" />
     <ClCompile Include="..\Code\CBlue44Tile.cpp" />
     <ClCompile Include="..\Code\CBackGround.cpp" />
     <ClCompile Include="..\Code\CBlue33Tile.cpp" />

--- a/Client/Include/Client.vcxproj
+++ b/Client/Include/Client.vcxproj
@@ -154,12 +154,16 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\Header\CBamboo.h" />
     <ClInclude Include="..\Header\CBlue44Tile.h" />
     <ClInclude Include="..\Header\CBackGround.h" />
     <ClInclude Include="..\Header\CBlue33Tile.h" />
+    <ClInclude Include="..\Header\CCar.h" />
     <ClInclude Include="..\Header\CCastle.h" />
     <ClInclude Include="..\Header\CBus.h" />
+    <ClInclude Include="..\Header\CCherryTree.h" />
     <ClInclude Include="..\Header\CChopStation.h" />
+    <ClInclude Include="..\Header\CCone.h" />
     <ClInclude Include="..\Header\CCucumber.h" />
     <ClInclude Include="..\Header\CCleanPlateStation.h" />
     <ClInclude Include="..\Header\CDirtyPlateStation.h" />
@@ -176,6 +180,7 @@
     <ClInclude Include="..\Header\CFryingpan.h" />
     <ClInclude Include="..\Header\CGasStation.h" />
     <ClInclude Include="..\Header\CHandState.h" />
+    <ClInclude Include="..\Header\CHydrant.h" />
     <ClInclude Include="..\Header\CIngredient.h" />
     <ClInclude Include="..\Header\CIngredientStation.h" />
     <ClInclude Include="..\Header\CInteract.h" />
@@ -190,6 +195,7 @@
     <ClInclude Include="..\Header\CNPC.h" />
     <ClInclude Include="..\Header\COnionKing.h" />
     <ClInclude Include="..\Header\CPasta.h" />
+    <ClInclude Include="..\Header\CPigeon.h" />
     <ClInclude Include="..\Header\CPink44Tile.h" />
     <ClInclude Include="..\Header\CPlant.h" />
     <ClInclude Include="..\Header\CPlate.h" />
@@ -197,6 +203,7 @@
     <ClInclude Include="..\Header\CPlayerHand.h" />
     <ClInclude Include="..\Header\CPlayerState.h" />
     <ClInclude Include="..\Header\CRealPlayer.h" />
+    <ClInclude Include="..\Header\CSandbag.h" />
     <ClInclude Include="..\Header\CSelectGameSystem.h" />
     <ClInclude Include="..\Header\CSelectLoading.h" />
     <ClInclude Include="..\Header\CSkyBox.h" />
@@ -206,6 +213,8 @@
     <ClInclude Include="..\Header\CTerrain.h" />
     <ClInclude Include="..\Header\CTestEffect.h" />
     <ClInclude Include="..\Header\CTomatoSoup.h" />
+    <ClInclude Include="..\Header\CTorch.h" />
+    <ClInclude Include="..\Header\CTrafficLight.h" />
     <ClInclude Include="..\Header\CTree.h" />
     <ClInclude Include="..\Header\CUi.h" />
     <ClInclude Include="..\Header\CUi_Button.h" />
@@ -254,12 +263,16 @@
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\Code\CBamboo.cpp" />
     <ClCompile Include="..\Code\CBlue44Tile.cpp" />
     <ClCompile Include="..\Code\CBackGround.cpp" />
     <ClCompile Include="..\Code\CBlue33Tile.cpp" />
+    <ClCompile Include="..\Code\CCar.cpp" />
     <ClCompile Include="..\Code\CCastle.cpp" />
     <ClCompile Include="..\Code\CBus.cpp" />
+    <ClCompile Include="..\Code\CCherryTree.cpp" />
     <ClCompile Include="..\Code\CChopStation.cpp" />
+    <ClCompile Include="..\Code\CCone.cpp" />
     <ClCompile Include="..\Code\CCucumber.cpp" />
     <ClCompile Include="..\Code\CCleanPlateStation.cpp" />
     <ClCompile Include="..\Code\CDirtyPlateStation.cpp" />
@@ -276,6 +289,7 @@
     <ClCompile Include="..\Code\CFryingpan.cpp" />
     <ClCompile Include="..\Code\CGasStation.cpp" />
     <ClCompile Include="..\Code\CHandState.cpp" />
+    <ClCompile Include="..\Code\CHydrant.cpp" />
     <ClCompile Include="..\Code\CIngredient.cpp" />
     <ClCompile Include="..\Code\CIngredientStation.cpp" />
     <ClCompile Include="..\Code\CInteract.cpp" />
@@ -290,6 +304,7 @@
     <ClCompile Include="..\Code\CNPC.cpp" />
     <ClCompile Include="..\Code\COnionKing.cpp" />
     <ClCompile Include="..\Code\CPasta.cpp" />
+    <ClCompile Include="..\Code\CPigeon.cpp" />
     <ClCompile Include="..\Code\CPink44Tile.cpp" />
     <ClCompile Include="..\Code\CPlant.cpp" />
     <ClCompile Include="..\Code\CPlate.cpp" />
@@ -297,6 +312,7 @@
     <ClCompile Include="..\Code\CPlayerHand.cpp" />
     <ClCompile Include="..\Code\CPlayerState.cpp" />
     <ClCompile Include="..\Code\CRealPlayer.cpp" />
+    <ClCompile Include="..\Code\CSandbag.cpp" />
     <ClCompile Include="..\Code\CSelectGameSystem.cpp" />
     <ClCompile Include="..\Code\CSelectLoading.cpp" />
     <ClCompile Include="..\Code\CSkyBox.cpp" />
@@ -306,6 +322,8 @@
     <ClCompile Include="..\Code\CTerrain.cpp" />
     <ClCompile Include="..\Code\CTestEffect.cpp" />
     <ClCompile Include="..\Code\CTomatoSoup.cpp" />
+    <ClCompile Include="..\Code\CTorch.cpp" />
+    <ClCompile Include="..\Code\CTrafficLight.cpp" />
     <ClCompile Include="..\Code\CTree.cpp" />
     <ClCompile Include="..\Code\CUi.cpp" />
     <ClCompile Include="..\Code\CUi_Button.cpp" />

--- a/Client/Include/Client.vcxproj.filters
+++ b/Client/Include/Client.vcxproj.filters
@@ -334,6 +334,36 @@
     <Filter Include="Object\10. MapObjects\02. Environment\02. Wall\02. WoodWall">
       <UniqueIdentifier>{86818245-107e-4bef-9a24-98368de95f31}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\03. Deco">
+      <UniqueIdentifier>{d8709e18-d570-4214-996b-104fdd968029}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\03. Deco\01. CherryTree">
+      <UniqueIdentifier>{0e3e1a1a-0e42-40ff-b1a7-918c8c61304a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\03. Deco\02. Car">
+      <UniqueIdentifier>{5d86ce4a-eae5-4fee-aeff-f74a9cf558a6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\03. Deco\03. Bamboo">
+      <UniqueIdentifier>{90bdbc52-81b3-4f9e-9533-bb41effc2afd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\03. Deco\07. Cone">
+      <UniqueIdentifier>{a0927b0e-a748-47c9-a366-4905f9aed78c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\03. Deco\06. Hydrant">
+      <UniqueIdentifier>{5cf4a52d-217f-4b44-afaa-d697de759d01}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\03. Deco\05. TrafficLight">
+      <UniqueIdentifier>{23cc0dc6-5230-447b-bf99-3d3a8b88d561}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\03. Deco\04. Torch">
+      <UniqueIdentifier>{a08e57a5-9ed6-4080-aa27-929f8862d150}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\03. Deco\08. Pigeon">
+      <UniqueIdentifier>{41e8ddc6-5f0d-4796-8888-14e843549f16}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\03. Deco\09. Sandbag">
+      <UniqueIdentifier>{ad976f44-9efe-46c5-9e6b-e9a6bad814df}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="framework.h">
@@ -626,12 +656,39 @@
     </ClInclude>
     <ClInclude Include="..\Header\CNPC.h">
       <Filter>Object\11. NPC\00. NPC</Filter>
-    </ClInclude> 
+    </ClInclude>
     <ClInclude Include="..\Header\CBrickWall.h">
       <Filter>Object\10. MapObjects\02. Environment\02. Wall\01. BrickWall</Filter>
     </ClInclude>
     <ClInclude Include="..\Header\CWoodWall.h">
       <Filter>Object\10. MapObjects\02. Environment\02. Wall\02. WoodWall</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Header\CCherryTree.h">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\01. CherryTree</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Header\CCar.h">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\02. Car</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Header\CBamboo.h">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\03. Bamboo</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Header\CTorch.h">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\04. Torch</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Header\CTrafficLight.h">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\05. TrafficLight</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Header\CHydrant.h">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\06. Hydrant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Header\CCone.h">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\07. Cone</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Header\CPigeon.h">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\08. Pigeon</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Header\CSandbag.h">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\09. Sandbag</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -904,6 +961,33 @@
     </ClCompile>
     <ClCompile Include="..\Code\CWoodWall.cpp">
       <Filter>Object\10. MapObjects\02. Environment\02. Wall\02. WoodWall</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CCherryTree.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\01. CherryTree</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CCar.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\02. Car</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CBamboo.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\03. Bamboo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CTorch.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\04. Torch</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CTrafficLight.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\05. TrafficLight</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CHydrant.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\06. Hydrant</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CCone.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\07. Cone</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CPigeon.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\08. Pigeon</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CSandbag.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\09. Sandbag</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Client/Include/Client.vcxproj.filters
+++ b/Client/Include/Client.vcxproj.filters
@@ -370,6 +370,9 @@
     <Filter Include="Object\10. MapObjects\02. Environment\02. Wall\04. AirBalloonBarrier">
       <UniqueIdentifier>{989638a1-c47d-41e1-a3ff-b306a4cb213e}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\03. Deco\10. Table">
+      <UniqueIdentifier>{30f5d73f-726c-4b08-814f-f92972d2a751}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="framework.h">
@@ -702,6 +705,9 @@
     <ClInclude Include="..\Header\CBarrier.h">
       <Filter>Object\10. MapObjects\02. Environment\02. Wall\04. AirBalloonBarrier</Filter>
     </ClInclude>
+    <ClInclude Include="..\Header\CTable.h">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\10. Table</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -1006,6 +1012,9 @@
     </ClCompile>
     <ClCompile Include="..\Code\CBarrier.cpp">
       <Filter>Object\10. MapObjects\02. Environment\02. Wall\04. AirBalloonBarrier</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CTable.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\03. Deco\10. Table</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Client/Include/Client.vcxproj.filters
+++ b/Client/Include/Client.vcxproj.filters
@@ -364,6 +364,12 @@
     <Filter Include="Object\10. MapObjects\02. Environment\03. Deco\09. Sandbag">
       <UniqueIdentifier>{ad976f44-9efe-46c5-9e6b-e9a6bad814df}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\02. Wall\03. AirBalloonBasket">
+      <UniqueIdentifier>{87f8eef2-2ba0-42e1-a141-ac048fc18d3a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Object\10. MapObjects\02. Environment\02. Wall\04. AirBalloonBarrier">
+      <UniqueIdentifier>{989638a1-c47d-41e1-a3ff-b306a4cb213e}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="framework.h">
@@ -690,6 +696,12 @@
     <ClInclude Include="..\Header\CSandbag.h">
       <Filter>Object\10. MapObjects\02. Environment\03. Deco\09. Sandbag</Filter>
     </ClInclude>
+    <ClInclude Include="..\Header\CBasket.h">
+      <Filter>Object\10. MapObjects\02. Environment\02. Wall\03. AirBalloonBasket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Header\CBarrier.h">
+      <Filter>Object\10. MapObjects\02. Environment\02. Wall\04. AirBalloonBarrier</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -988,6 +1000,12 @@
     </ClCompile>
     <ClCompile Include="..\Code\CSandbag.cpp">
       <Filter>Object\10. MapObjects\02. Environment\03. Deco\09. Sandbag</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CBasket.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\02. Wall\03. AirBalloonBasket</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Code\CBarrier.cpp">
+      <Filter>Object\10. MapObjects\02. Environment\02. Wall\04. AirBalloonBarrier</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- 인게임 벽 2종 추가 (5, 6 스테이지에 들어가는 열기구 벽으로 Basket과 Barrier)
- 인게임 데코 10종 추가 (평면 9종 : CherryTree, Car, Bamboo, Torch, TrafficLight, Hydrant, Cone, Pigeon, Sandbag / 큐브 1종 : Table)
- 모든 데코는 Set_Scale을 가지고 있으며, 문서에 적절한 스케일 값 작성
- 텍스쳐 관련해서 TrafficLight와 Table은 Set_Texture 함수를 호출해서 상황에 맞는 적절한 텍스쳐 설정 필요 / CherryTree, Car, Bamboo, Pigeon, Sandbag은 랜덤 텍스쳐